### PR TITLE
Chore(i18n): Global translations refresh, updated French translation and more

### DIFF
--- a/data/io.github.nokse22.Exhibit.metainfo.xml.in
+++ b/data/io.github.nokse22.Exhibit.metainfo.xml.in
@@ -7,10 +7,14 @@
   <name>Exhibit</name>
   <summary>Preview your 3D models</summary>
   <description>
-    <p>Based on the F3D library, it supports many file formats, from digital content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, USD, Alembic and many more.
-You can drag and drop 3d models into the app and export an image of the rendered model.
-Change many settings like tone mapping, ambient occlusion, anti aliasing, material roughness, metallic, color and opacity to achieve the perfect render.
-You can use an HDRI image or a custom color as a background.</p>
+    <p>
+      Based on the F3D library, it supports many file formats, from digital content to scientific
+      datasets including glTF, STL, STEP, PLY, OBJ, FBX, USD, Alembic and many more. You can drag
+      and drop 3d models into the app and export an image of the rendered model. Change many
+      settings like tone mapping, ambient occlusion, anti aliasing, material roughness, metallic,
+      color and opacity to achieve the perfect render. You can use an HDRI image or a custom color
+      as a background.
+    </p>
   </description>
 
   <developer id="io.github.nokse22">
@@ -25,9 +29,11 @@ You can use an HDRI image or a custom color as a background.</p>
 
   <translation type="gettext">exhibit</translation>
   <!-- All graphical applications having a desktop file must have this tag in the MetaInfo.
-     If this is present, appstreamcli compose will pull icons, keywords and categories from the desktop file. -->
+  If this is present, appstreamcli compose will pull icons, keywords and categories from the desktop
+  file. -->
   <launchable type="desktop-id">io.github.nokse22.Exhibit.desktop</launchable>
-  <!-- Use the OARS website (https://hughsie.github.io/oars/generate.html) to generate these and make sure to use oars-1.1 -->
+  <!-- Use the OARS website (https://hughsie.github.io/oars/generate.html) to generate these and
+  make sure to use oars-1.1 -->
   <content_rating type="oars-1.1" />
 
   <!-- Applications should set a brand color in both light and dark variants like so -->
@@ -38,33 +44,47 @@ You can use an HDRI image or a custom color as a background.</p>
 
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%201.png</image>
-      <caption>3D Bechy</caption>
+      <image>
+        https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%201.png
+      </image>
+      <caption>3D Benchy</caption>
     </screenshot>
-	  <screenshot>
-	    <image>https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%202.png</image>
-	    <caption>Retro Computer Setup with a HDRI skybox</caption>
-	  </screenshot>
     <screenshot>
-	    <image>https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%203.png</image>
-	    <caption>Green Metallic Suzanne</caption>
-	  </screenshot>
+      <image>
+        https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%202.png
+      </image>
+      <caption>Retro Computer Setup with a HDRI skybox</caption>
+    </screenshot>
     <screenshot>
-	    <image>https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%204.png</image>
-	    <caption>Cow with an HDRI background and dark theme</caption>
-	  </screenshot>
+      <image>
+        https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%203.png
+      </image>
+      <caption>Green Metallic Suzanne</caption>
+    </screenshot>
     <screenshot>
-	    <image>https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%205.png</image>
-	    <caption>Vase 3d scan with HDRI skybox</caption>
-	  </screenshot>
+      <image>
+        https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%204.png
+      </image>
+      <caption>Cow with an HDRI background and dark theme</caption>
+    </screenshot>
     <screenshot>
-	    <image>https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%206.png</image>
-	    <caption>Point cloud of a boat with dark theme</caption>
-	  </screenshot>
+      <image>
+        https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%205.png
+      </image>
+      <caption>Vase 3d scan with HDRI skybox</caption>
+    </screenshot>
     <screenshot>
-	    <image>https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%207.png</image>
-	    <caption>Rigged model showing armature with dark theme</caption>
-	  </screenshot>
+      <image>
+        https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%206.png
+      </image>
+      <caption>Point cloud of a boat with dark theme</caption>
+    </screenshot>
+    <screenshot>
+      <image>
+        https://raw.githubusercontent.com/Nokse22/Exhibit/master/data/resources/screenshot%207.png
+      </image>
+      <caption>Rigged model showing armature with dark theme</caption>
+    </screenshot>
   </screenshots>
 
   <releases>

--- a/po/Exhibit.pot
+++ b/po/Exhibit.pot
@@ -1,37 +1,38 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the Exhibit package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-04 15:16+0200\n"
+"POT-Creation-Date: 2026-02-26 22:15+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:848
-#: data/ui/window.ui:11 data/ui/window.ui:77 data/ui/window.ui:155
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:73
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr ""
 
@@ -46,371 +47,431 @@ msgid ""
 "or a custom color as a background."
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "3D Bechy"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+msgid "3D Benchy"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
 msgid "Retro Computer Setup with a HDRI skybox"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
 msgid "Green Metallic Suzanne"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
 msgid "Cow with an HDRI background and dark theme"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:58
-msgid "Nissan Fairlady with dark theme"
-msgstr ""
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:62
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
 msgid "Vase 3d scan with HDRI skybox"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
 msgid "Point cloud of a boat with dark theme"
 msgstr ""
 
-#: src/main.py:140
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+msgid "Rigged model showing armature with dark theme"
+msgstr ""
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr ""
 
-#: src/window.py:713
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr ""
 
-#: src/window.py:853
+#: src/window.py:847
+msgid "Loading {}"
+msgstr ""
+
+#: src/window.py:917
+msgid "Exhibit - {}"
+msgstr ""
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr ""
 
-#: src/window.py:869
+#: src/window.py:958
 msgid "Save File"
 msgstr ""
 
-#: data/ui/window.ui:49 data/ui/window.ui:178 data/ui/window.ui:185
-#: data/ui/window.ui:711
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
+
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr ""
 
-#: data/ui/window.ui:69
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr ""
 
-#: data/ui/window.ui:95
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr ""
 
-#: data/ui/window.ui:99
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr ""
 
-#: data/ui/window.ui:103
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr ""
 
-#: data/ui/window.ui:161 data/ui/window.ui:719
-msgid "Open With External App"
-msgstr ""
-
-#: data/ui/window.ui:171
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr ""
 
-#: data/ui/window.ui:208
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr ""
 
-#: data/ui/window.ui:222
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr ""
 
-#: data/ui/window.ui:227
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr ""
 
-#: data/ui/window.ui:234
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr ""
 
-#: data/ui/window.ui:235
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr ""
 
-#: data/ui/window.ui:242
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr ""
 
-#: data/ui/window.ui:243
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr ""
 
-#: data/ui/window.ui:250
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr ""
 
-#: data/ui/window.ui:257
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr ""
 
-#: data/ui/window.ui:258
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr ""
 
-#: data/ui/window.ui:273
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr ""
 
-#: data/ui/window.ui:282
+#: data/ui/window.ui:327
 msgid "Model Rendering"
 msgstr ""
 
-#: data/ui/window.ui:287
+#: data/ui/window.ui:332
 msgid "Show All Edges"
 msgstr ""
 
-#: data/ui/window.ui:294
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr ""
 
-#: data/ui/window.ui:316
-msgid "Show Spheres"
+#: data/ui/window.ui:359
+msgid "Show Point Sprites"
 msgstr ""
 
-#: data/ui/window.ui:323
-msgid "Points Size"
+#: data/ui/window.ui:364
+msgid "Point Sprites Type"
 msgstr ""
 
-#: data/ui/window.ui:347 data/ui/window.ui:361
-msgid "Model"
+#: data/ui/window.ui:368
+msgid "Sphere"
 msgstr ""
 
-#: data/ui/window.ui:367
-msgid "Load type"
+#: data/ui/window.ui:369
+msgid "Gaussian"
 msgstr ""
 
-#: data/ui/window.ui:371
-msgid "Geometry"
-msgstr ""
-
-#: data/ui/window.ui:372 data/ui/window.ui:488
-msgid "Scene"
-msgstr ""
-
-#: data/ui/window.ui:385
-msgid "Material"
+#: data/ui/window.ui:377
+msgid "Sprite Size"
 msgstr ""
 
 #: data/ui/window.ui:390
+msgid "Points Size"
+msgstr ""
+
+#: data/ui/window.ui:413
+msgid "Model"
+msgstr ""
+
+#: data/ui/window.ui:427
+msgid "Material"
+msgstr ""
+
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr ""
 
-#: data/ui/window.ui:406
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr ""
 
-#: data/ui/window.ui:423
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr ""
 
-#: data/ui/window.ui:441
+#: data/ui/window.ui:483
 msgid "Color"
 msgstr ""
 
-#: data/ui/window.ui:447
+#: data/ui/window.ui:489
 msgid "Coloration"
 msgstr ""
 
-#: data/ui/window.ui:451
+#: data/ui/window.ui:493
 msgid "Custom"
 msgstr ""
 
-#: data/ui/window.ui:452
+#: data/ui/window.ui:494
 msgid "Normal"
 msgstr ""
 
-#: data/ui/window.ui:453
+#: data/ui/window.ui:495
 msgid "Magnitude"
 msgstr ""
 
-#: data/ui/window.ui:454
+#: data/ui/window.ui:496
 msgid "Direct"
 msgstr ""
 
-#: data/ui/window.ui:464
+#: data/ui/window.ui:506 data/ui/window.ui:513
 msgid "Model Color"
 msgstr ""
 
-#: data/ui/window.ui:502
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr ""
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr ""
 
-#: data/ui/window.ui:507
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr ""
 
-#: data/ui/window.ui:514
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr ""
 
-#: data/ui/window.ui:523
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr ""
 
-#: data/ui/window.ui:528
+#: data/ui/window.ui:582
 msgid "HDRI as Background"
 msgstr ""
 
-#: data/ui/window.ui:529
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr ""
 
-#: data/ui/window.ui:536
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr ""
 
-#: data/ui/window.ui:543
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr ""
 
-#: data/ui/window.ui:550
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr ""
 
-#: data/ui/window.ui:572
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr ""
 
-#: data/ui/window.ui:573
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr ""
 
-#: data/ui/window.ui:580
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr ""
 
-#: data/ui/window.ui:581
-msgid "Transparent colors not supported"
-msgstr ""
-
-#: data/ui/window.ui:605
+#: data/ui/window.ui:661
 msgid "More"
 msgstr ""
 
-#: data/ui/window.ui:619
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr ""
 
-#: data/ui/window.ui:624
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr ""
 
-#: data/ui/window.ui:631
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr ""
 
-#: data/ui/window.ui:632
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr ""
 
-#: data/ui/window.ui:636
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr ""
 
-#: data/ui/window.ui:637
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr ""
 
-#: data/ui/window.ui:638
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr ""
 
-#: data/ui/window.ui:639
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr ""
 
-#: data/ui/window.ui:640
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr ""
 
-#: data/ui/window.ui:641
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr ""
 
-#: data/ui/window.ui:653
+#: data/ui/window.ui:707
+msgid "Animation"
+msgstr ""
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
 msgid "Loading"
 msgstr ""
 
-#: data/ui/window.ui:658
+#: data/ui/window.ui:761
 msgid "Automatic Settings"
 msgstr ""
 
-#: data/ui/window.ui:659
+#: data/ui/window.ui:762
 msgid "When loading choose the best presets for the file"
 msgstr ""
 
-#: data/ui/window.ui:672
+#: data/ui/window.ui:775
 msgid "Reload On Change"
 msgstr ""
 
-#: data/ui/window.ui:673
+#: data/ui/window.ui:776
 msgid "Check for file change"
 msgstr ""
 
-#: data/ui/window.ui:702
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr ""
 
-#: data/ui/window.ui:728
-msgid "Toggle Orthographic"
-msgstr ""
-
-#: data/ui/window.ui:736
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr ""
 
-#: data/ui/window.ui:798
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr ""
 
-#: data/ui/window.ui:803
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr ""
 
-#: data/ui/window.ui:808
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr ""
 
-#: data/ui/window.ui:813 data/ui/window.ui:863
+#: data/ui/window.ui:926 data/ui/window.ui:990
 msgid "_New Window"
 msgstr ""
 
-#: data/ui/window.ui:819
+#: data/ui/window.ui:930
 msgid "_Load New File"
 msgstr ""
 
-#: data/ui/window.ui:825
+#: data/ui/window.ui:938
 msgid "_Export Image"
 msgstr ""
 
-#: data/ui/window.ui:831 data/ui/window.ui:869
+#: data/ui/window.ui:942
+msgid "_Open In External App"
+msgstr ""
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
 msgid "_Help"
 msgstr ""
 
-#: data/ui/window.ui:835 data/ui/window.ui:873
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr ""
 
-#: data/ui/window.ui:839 data/ui/window.ui:877
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr ""
 
-#: data/ui/window.ui:849
+#: data/ui/window.ui:966
 msgid "Save Current Settings"
 msgstr ""
 
-#: data/ui/window.ui:855
+#: data/ui/window.ui:972
+msgid "Orthonographic"
+msgstr ""
+
+#: data/ui/window.ui:978
 msgid "Open HDRI Folder"
+msgstr ""
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+msgid "Open HDRI"
 msgstr ""

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,10 +1,10 @@
 bg
 de
 es
+fr
 hi
 it
 nb
 pt_BR
-fr
 ru
 uk

--- a/po/bg.po
+++ b/po/bg.po
@@ -1,15 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Bulgarian translation.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
 # twlvnn <kraft_werk@tutanota.com>, 2024.
 # twlvnn kraftwerk <kraft_werk@tutanota.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: exhibit\n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-04 22:15+0200\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-06-07 23:03+0200\n"
 "Last-Translator: twlvnn kraftwerk <kraft_werk@tutanota.com>\n"
 "Language-Team: Bulgarian <dict-notifications@fsa-bg.org>\n"
@@ -20,28 +19,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "X-Generator: Gtranslator 46.1\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 data/window.ui:20
-#: data/window.ui:84
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Изложба"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "Преглед на 3D файлове"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Преглеждайте вашите 3D модели"
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:10
+#, fuzzy
+#| msgid ""
+#| "Based on the F3D library that supports many file formats, from digital "
+#| "content to scientific datasets including glTF, USD, STL, STEP, PLY, OBJ, "
+#| "FBX, Alembic and many more. Drag and drop 3d models into the app and "
+#| "export an image of the 3d model. It supports tone mapping, ambient "
+#| "occlusion, anti aliasing and more. You can use an HDRI image or a custom "
+#| "color as a background."
 msgid ""
-"Based on the F3D library that supports many file formats, from digital "
-"content to scientific datasets including glTF, USD, STL, STEP, PLY, OBJ, "
-"FBX, Alembic and many more. Drag and drop 3d models into the app and export "
-"an image of the 3d model. It supports tone mapping, ambient occlusion, anti "
-"aliasing and more. You can use an HDRI image or a custom color as a "
-"background."
+"Based on the F3D library, it supports many file formats, from digital "
+"content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
+"USD, Alembic and many more. You can drag and drop 3d models into the app and "
+"export an image of the rendered model. Change many settings like tone "
+"mapping, ambient occlusion, anti aliasing, material roughness, metallic, "
+"color and opacity to achieve the perfect render. You can use an HDRI image "
+"or a custom color as a background."
 msgstr ""
 "Основана на F3D библиотеката, която поддържа много типове файлове - от "
 "цифрово съдържание до набор от научни данни, включително glTF, USD, STL, "
@@ -50,262 +63,532 @@ msgstr ""
 "тоналностите, оклузия, заглаждане и др. Може да използвате HDRI изображение "
 "или друг цвят като фон."
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "Planetary Reducer"
-msgstr "Planetary Reducer"
-
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
-msgid "Nissan Fairlady"
-msgstr "Nissan Fairlady"
+msgid "3D Benchy"
+msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
-msgid "Retro Computer Setup with a HDRI background"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
+#, fuzzy
+#| msgid "Retro Computer Setup with a HDRI background"
+msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Ретро компютър с HDRI фон"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
-msgid "Benchy with dark theme"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
+msgid "Green Metallic Suzanne"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
+msgid "Cow with an HDRI background and dark theme"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+msgid "Vase 3d scan with HDRI skybox"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
+#, fuzzy
+#| msgid "Benchy with dark theme"
+msgid "Point cloud of a boat with dark theme"
 msgstr "Benchy с тъмна тема"
 
-#: src/window.py:293
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Benchy with dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Benchy с тъмна тема"
+
+#: src/main.py:129
+msgid "Checkout F3D"
+msgstr ""
+
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Отваряне на файл"
 
-#: src/window.py:341
-msgid "Can't open "
+#: src/window.py:847
+#, fuzzy
+#| msgid "Load"
+msgid "Loading {}"
+msgstr "Отваряне"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Изложба"
+
+#: src/window.py:942
+#, fuzzy
+#| msgid "Can't open "
+msgid "Can't open"
 msgstr "Не може да се отвори"
 
-#: src/window.py:374
+#: src/window.py:958
 msgid "Save File"
 msgstr "Запазване на файл"
 
-#: src/window.py:375
-msgid "image.png"
-msgstr "изображение.png"
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
 
-#: src/window.py:576
-msgid "Open Skybox File"
-msgstr "Отваряне на файл небесно поле"
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
 
-#: data/window.ui:27
-msgid "Reset to Bounds"
-msgstr "Връщане до границите"
-
-#: data/window.ui:35
-msgid "Toggle Orthographic"
-msgstr "Превключване на ортографиране"
-
-#: data/window.ui:43
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Меню"
 
-#: data/window.ui:76
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Отваряне"
 
-#: data/window.ui:80
-msgid "Load any file to view it in 3D"
-msgstr "Отворете файл, за да го видите в 3D"
+#: data/ui/window.ui:110
+msgid "Try Another"
+msgstr ""
 
-#: data/window.ui:145
-msgid "_Open New Window"
-msgstr "_Отваряне на нов прозорец"
+#: data/ui/window.ui:114
+msgid "Couldn't load the file"
+msgstr ""
 
-#: data/window.ui:151
-msgid "_Load New Model"
-msgstr "_Отваряне на нов модел"
+#: data/ui/window.ui:118
+msgid "Error Loading File"
+msgstr ""
 
-#: data/window.ui:157
-msgid "_Save As Image"
-msgstr "_Запазване като изображение"
+#: data/ui/window.ui:216
+msgid "Close Sidebar"
+msgstr ""
 
-#: data/window.ui:163
-msgid "_Preferences"
-msgstr "_Настройки"
-
-#: data/window.ui:167
-msgid "_Keyboard Shortcuts"
-msgstr "_Клавишни комбинации"
-
-#: data/window.ui:171
-msgid "_About Exhibit"
-msgstr "_Относно „Изложба“"
-
-#: data/preferences.ui:12 data/preferences.ui:17
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Генериране"
 
-#: data/preferences.ui:22
+#: data/ui/window.ui:267
+#, fuzzy
+#| msgid "Render"
+msgid "Rendering"
+msgstr "Генериране"
+
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "Полупрозрачно"
 
-#: data/preferences.ui:29
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "Транслиране на тоналностите"
 
-#: data/preferences.ui:30
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "Правилно картографиране на цветовете спрямо цветовете на монитора"
 
-#: data/preferences.ui:37
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "Оклузия "
 
-#: data/preferences.ui:38
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "Предоставя приблизителни сенки"
 
-#: data/preferences.ui:45
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "Заглаждане"
 
-#: data/preferences.ui:52
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "Светлина с HDRI"
 
-#: data/preferences.ui:53
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr "Осветете сцената с помощта на заредения HDRI или по подразбиране"
 
-#: data/preferences.ui:68
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "Светлинен интензитет"
 
-#: data/preferences.ui:77
-msgid "Edges"
-msgstr "Ръбове"
+#: data/ui/window.ui:327
+#, fuzzy
+#| msgid "3D Model Viewer"
+msgid "Model Rendering"
+msgstr "Преглед на 3D файлове"
 
-#: data/preferences.ui:82
-msgid "Show Edges"
+#: data/ui/window.ui:332
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Show All Edges"
 msgstr "Показване на ръбовете"
 
-#: data/preferences.ui:89
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Широчина на ръбовете"
 
-#: data/preferences.ui:109
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Show Point Sprites"
+msgstr "Показване на ръбовете"
+
+#: data/ui/window.ui:364
+msgid "Point Sprites Type"
+msgstr ""
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Sphere"
+msgstr "Показване на ръбовете"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+msgid "Sprite Size"
+msgstr ""
+
+#: data/ui/window.ui:390
+msgid "Points Size"
+msgstr ""
+
+#: data/ui/window.ui:413
+msgid "Model"
+msgstr ""
+
+#: data/ui/window.ui:427
+msgid "Material"
+msgstr ""
+
+#: data/ui/window.ui:432
+msgid "Model Metallic"
+msgstr ""
+
+#: data/ui/window.ui:448
+msgid "Model Roughness"
+msgstr ""
+
+#: data/ui/window.ui:465
+msgid "Model Opacity"
+msgstr ""
+
+#: data/ui/window.ui:483
+msgid "Color"
+msgstr ""
+
+#: data/ui/window.ui:489
+msgid "Coloration"
+msgstr ""
+
+#: data/ui/window.ui:493
+msgid "Custom"
+msgstr ""
+
+#: data/ui/window.ui:494
+msgid "Normal"
+msgstr ""
+
+#: data/ui/window.ui:495
+msgid "Magnitude"
+msgstr ""
+
+#: data/ui/window.ui:496
+#, fuzzy
+#| msgid "Up Direction"
+msgid "Direct"
+msgstr "Посока нагоре"
+
+#: data/ui/window.ui:506 data/ui/window.ui:513
+msgid "Model Color"
+msgstr ""
+
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
 msgid "Scene"
 msgstr "Сцена"
 
-#: data/preferences.ui:114
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Мрежа"
 
-#: data/preferences.ui:119
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Показване на мрежата"
 
-#: data/preferences.ui:126
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Абсолютна мрежа"
 
-#: data/preferences.ui:135
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Фон"
 
-#: data/preferences.ui:140
-msgid "HDRI as Backgound"
+#: data/ui/window.ui:582
+#, fuzzy
+#| msgid "HDRI as Backgound"
+msgid "HDRI as Background"
 msgstr "HDRI като фон"
 
-#: data/preferences.ui:141
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Използвайте заредения HDRI или фона по подразбиране"
 
-#: data/preferences.ui:148
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "HDRI изображение"
 
-#: data/preferences.ui:161
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Замъгляване на фона"
 
-#: data/preferences.ui:168
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Кръг на замъгляване"
 
-#: data/preferences.ui:190
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Друг цвят"
 
-#: data/preferences.ui:191
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "HDRI фона има приоритет"
 
-#: data/preferences.ui:198
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Цвят на фона"
 
-#: data/preferences.ui:199
-msgid "Transparent colors not supported"
-msgstr "Прозрачни цветове не се поддържат"
-
-#: data/preferences.ui:219
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Още"
 
-#: data/preferences.ui:225
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Навигация"
 
-#: data/preferences.ui:230
-msgid "Alwayas Point Up"
+#: data/ui/window.ui:680
+#, fuzzy
+#| msgid "Alwayas Point Up"
+msgid "Always Point Up"
 msgstr "Винаги насочвайте нагоре"
 
-#: data/preferences.ui:237
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Посока нагоре"
 
-#: data/preferences.ui:242
+#: data/ui/window.ui:688
+msgid "Changing it will reload the file"
+msgstr ""
+
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr "- X"
 
-#: data/preferences.ui:243
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr "+ X"
 
-#: data/preferences.ui:244
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr "- Y"
 
-#: data/preferences.ui:245
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr "+ Y"
 
-#: data/preferences.ui:246
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr "- Z"
 
-#: data/preferences.ui:247
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr "+ Z"
 
-#: data/preferences.ui:259
-msgid "Other Settings"
-msgstr "Допълнителни настройки"
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Навигация"
 
-#: data/preferences.ui:264
-msgid "Automatic Up Direction"
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
+#, fuzzy
+#| msgid "Load"
+msgid "Loading"
+msgstr "Отваряне"
+
+#: data/ui/window.ui:761
+#, fuzzy
+#| msgid "Automatic Up Direction"
+msgid "Automatic Settings"
 msgstr "Автоматична посока нагоре"
 
-#: data/preferences.ui:265
-msgid "When loading choose the best up direction"
+#: data/ui/window.ui:762
+#, fuzzy
+#| msgid "When loading choose the best up direction"
+msgid "When loading choose the best presets for the file"
 msgstr "При зареждане се избира най-добрата посока нагоре"
 
-#: data/preferences.ui:272
-msgid "Save Settings"
+#: data/ui/window.ui:775
+msgid "Reload On Change"
+msgstr ""
+
+#: data/ui/window.ui:776
+msgid "Check for file change"
+msgstr ""
+
+#: data/ui/window.ui:826
+msgid "Reveal Sidebar"
+msgstr ""
+
+#: data/ui/window.ui:849
+msgid "Reset to Bounds"
+msgstr "Връщане до границите"
+
+#: data/ui/window.ui:911
+msgid "Follow System"
+msgstr ""
+
+#: data/ui/window.ui:916
+msgid "Light Theme"
+msgstr ""
+
+#: data/ui/window.ui:921
+msgid "Dark Theme"
+msgstr ""
+
+#: data/ui/window.ui:926 data/ui/window.ui:990
+#, fuzzy
+#| msgid "_Open New Window"
+msgid "_New Window"
+msgstr "_Отваряне на нов прозорец"
+
+#: data/ui/window.ui:930
+#, fuzzy
+#| msgid "_Load New Model"
+msgid "_Load New File"
+msgstr "_Отваряне на нов модел"
+
+#: data/ui/window.ui:938
+msgid "_Export Image"
+msgstr ""
+
+#: data/ui/window.ui:942
+msgid "_Open In External App"
+msgstr ""
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
+msgid "_Help"
+msgstr ""
+
+#: data/ui/window.ui:952 data/ui/window.ui:1000
+msgid "_Keyboard Shortcuts"
+msgstr "_Клавишни комбинации"
+
+#: data/ui/window.ui:956 data/ui/window.ui:1004
+msgid "_About Exhibit"
+msgstr "_Относно „Изложба“"
+
+#: data/ui/window.ui:966
+#, fuzzy
+#| msgid "Save Settings"
+msgid "Save Current Settings"
 msgstr "Запазване на настройките"
 
-#: data/preferences.ui:282
-msgid "Restore Settings"
-msgstr "Възстановяване на настройките"
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Превключване на ортографиране"
 
-#: data/preferences.ui:298
-msgid "Reset Settings"
-msgstr "Връщане на настройките"
+#: data/ui/window.ui:978
+#, fuzzy
+#| msgid "Open File"
+msgid "Open HDRI Folder"
+msgstr "Отваряне на файл"
 
-#: data/preferences.ui:307
-msgid ""
-"Preferences are per window basis, if you save them next time you will open "
-"the app it will start with these preferences"
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
 msgstr ""
-"Настройките са за всеки прозорец, ако ги запазите, следващият път, когато "
-"отворите приложението, то ще започне с тези настройки."
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open File"
+msgid "Open HDRI"
+msgstr "Отваряне на файл"
+
+#, fuzzy
+#~| msgid "Benchy with dark theme"
+#~ msgid "Nissan Fairlady with dark theme"
+#~ msgstr "Benchy с тъмна тема"
+
+#, fuzzy
+#~| msgid "Load"
+#~ msgid "Load type"
+#~ msgstr "Отваряне"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "Прозрачни цветове не се поддържат"
+
+#~ msgid "Planetary Reducer"
+#~ msgstr "Planetary Reducer"
+
+#~ msgid "Nissan Fairlady"
+#~ msgstr "Nissan Fairlady"
+
+#~ msgid "image.png"
+#~ msgstr "изображение.png"
+
+#~ msgid "Open Skybox File"
+#~ msgstr "Отваряне на файл небесно поле"
+
+#~ msgid "Load any file to view it in 3D"
+#~ msgstr "Отворете файл, за да го видите в 3D"
+
+#~ msgid "_Save As Image"
+#~ msgstr "_Запазване като изображение"
+
+#~ msgid "_Preferences"
+#~ msgstr "_Настройки"
+
+#~ msgid "Edges"
+#~ msgstr "Ръбове"
+
+#~ msgid "Other Settings"
+#~ msgstr "Допълнителни настройки"
+
+#~ msgid "Restore Settings"
+#~ msgstr "Възстановяване на настройките"
+
+#~ msgid "Reset Settings"
+#~ msgstr "Връщане на настройките"
+
+#~ msgid ""
+#~ "Preferences are per window basis, if you save them next time you will "
+#~ "open the app it will start with these preferences"
+#~ msgstr ""
+#~ "Настройките са за всеки прозорец, ако ги запазите, следващият път, когато "
+#~ "отворите приложението, то ще започне с тези настройки."

--- a/po/de.po
+++ b/po/de.po
@@ -1,16 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# German translation.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
+# VortexAcherontic <vortex@z-ray.de>, 2024.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-04 15:16+0200\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-10-23 14:51+0200\n"
-"Last-Translator: \n"
+"Last-Translator: VortexAcherontic\n"
 "Language-Team: \n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -18,21 +17,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:848
-#: data/ui/window.ui:11 data/ui/window.ui:77 data/ui/window.ui:155
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Ausstellung"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "3D Modelbetrachter"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+#, fuzzy
+#| msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:73
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Betrachte dein 3D Model"
 
@@ -56,371 +58,467 @@ msgstr ""
 "Transparenz um das perfekte Aussehen zu erreichen. Außerdem können HDR "
 "Bilder für einen Benutzerdefinierten Hintergrund verwendet werden."
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "3D Bechy"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#, fuzzy
+#| msgid "3D Bechy"
+msgid "3D Benchy"
 msgstr "3D Benchy"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
 msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Alter Computer mit HDR Hintergrund"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
 msgid "Green Metallic Suzanne"
 msgstr "Grün-metallische Suzanne"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
 msgid "Cow with an HDRI background and dark theme"
 msgstr "Kuh mit HDR Hintergrund im dunklem Thema"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:58
-msgid "Nissan Fairlady with dark theme"
-msgstr "Nissan Fairlady im dunklem Thema"
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:62
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
 msgid "Vase 3d scan with HDRI skybox"
 msgstr "3D Scan einer Vase mit HDR Hintergrund"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
 msgid "Point cloud of a boat with dark theme"
 msgstr "Ein Boot als Punktewolke im dunklem Thema"
 
-#: src/main.py:140
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Point cloud of a boat with dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Ein Boot als Punktewolke im dunklem Thema"
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr "F3D ausschecken"
 
-#: src/window.py:713
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Datei öffnen"
 
-#: src/window.py:853
+#: src/window.py:847
+#, fuzzy
+#| msgid "Loading"
+msgid "Loading {}"
+msgstr "Lade"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Ausstellung"
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr "Kann nicht geöffnet werden"
 
-#: src/window.py:869
+#: src/window.py:958
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: data/ui/window.ui:49 data/ui/window.ui:178 data/ui/window.ui:185
-#: data/ui/window.ui:711
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
+
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Menü"
 
-#: data/ui/window.ui:69
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Laden"
 
-#: data/ui/window.ui:95
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr "Ein anderes Verssuchen"
 
-#: data/ui/window.ui:99
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr "Datei konnte nicht geladen werden"
 
-#: data/ui/window.ui:103
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "Fehler beim Laden der Datei"
 
-#: data/ui/window.ui:161 data/ui/window.ui:719
-msgid "Open With External App"
-msgstr "In externer Anwendung öffnen"
-
-#: data/ui/window.ui:171
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "Seitenleiste schließen"
 
-#: data/ui/window.ui:208
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Render"
 
-#: data/ui/window.ui:222
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "Rendering"
 
-#: data/ui/window.ui:227
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "Durschsichtigkeit"
 
-#: data/ui/window.ui:234
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "Farbton"
 
-#: data/ui/window.ui:235
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "Stimmt die Farben mit dem Farbraumes des Monitors ab"
 
-#: data/ui/window.ui:242
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "Umgebungsverdeckung"
 
-#: data/ui/window.ui:243
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "Bietet angenäherte Schatten"
 
-#: data/ui/window.ui:250
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "Antialiasing"
 
-#: data/ui/window.ui:257
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "Mit HDRI belichten"
 
-#: data/ui/window.ui:258
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr "Belichtet die Szene mit dem Standard oder dem geladenen HDR Bild"
 
-#: data/ui/window.ui:273
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "Lichtintensität"
 
-#: data/ui/window.ui:282
+#: data/ui/window.ui:327
 msgid "Model Rendering"
 msgstr "Model Rendering"
 
-#: data/ui/window.ui:287
+#: data/ui/window.ui:332
 msgid "Show All Edges"
 msgstr "Alle Kanten anzeigen"
 
-#: data/ui/window.ui:294
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Kantenbreite"
 
-#: data/ui/window.ui:316
-msgid "Show Spheres"
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Show Point Sprites"
 msgstr "Zeige Spheren"
 
-#: data/ui/window.ui:323
+#: data/ui/window.ui:364
+#, fuzzy
+#| msgid "Points Size"
+msgid "Point Sprites Type"
+msgstr "Punktgröße"
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Sphere"
+msgstr "Zeige Spheren"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+#, fuzzy
+#| msgid "Points Size"
+msgid "Sprite Size"
+msgstr "Punktgröße"
+
+#: data/ui/window.ui:390
 msgid "Points Size"
 msgstr "Punktgröße"
 
-#: data/ui/window.ui:347 data/ui/window.ui:361
+#: data/ui/window.ui:413
 msgid "Model"
 msgstr "Model"
 
-#: data/ui/window.ui:367
-msgid "Load type"
-msgstr "Ladetyp"
-
-#: data/ui/window.ui:371
-msgid "Geometry"
-msgstr "Gemoetrie"
-
-#: data/ui/window.ui:372 data/ui/window.ui:488
-msgid "Scene"
-msgstr "Szene"
-
-#: data/ui/window.ui:385
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "Material"
 
-#: data/ui/window.ui:390
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "Model Metallisch"
 
-#: data/ui/window.ui:406
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "Model Rauheit"
 
-#: data/ui/window.ui:423
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "Model Deckfähigkeit"
 
-#: data/ui/window.ui:441
+#: data/ui/window.ui:483
 msgid "Color"
 msgstr "Farbe"
 
-#: data/ui/window.ui:447
+#: data/ui/window.ui:489
 msgid "Coloration"
 msgstr "Färbung"
 
-#: data/ui/window.ui:451
+#: data/ui/window.ui:493
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: data/ui/window.ui:452
+#: data/ui/window.ui:494
 msgid "Normal"
 msgstr "Normale"
 
-#: data/ui/window.ui:453
+#: data/ui/window.ui:495
 msgid "Magnitude"
 msgstr "Außmaße"
 
-#: data/ui/window.ui:454
+#: data/ui/window.ui:496
 msgid "Direct"
 msgstr "Direkt"
 
-#: data/ui/window.ui:464
+#: data/ui/window.ui:506 data/ui/window.ui:513
 msgid "Model Color"
 msgstr "Modelfarbe"
 
-#: data/ui/window.ui:502
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "Szene"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Gitter"
 
-#: data/ui/window.ui:507
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Zeige Gitter"
 
-#: data/ui/window.ui:514
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Absolutes Gitter"
 
-#: data/ui/window.ui:523
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Hintergrund"
 
-#: data/ui/window.ui:528
+#: data/ui/window.ui:582
 msgid "HDRI as Background"
 msgstr "HDRI als Hintergrund"
 
-#: data/ui/window.ui:529
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Geladenes HDRI oder den Standard als Hintergrund verwenden"
 
-#: data/ui/window.ui:536
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "HDR Bild"
 
-#: data/ui/window.ui:543
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Hintergrund verwischen"
 
-#: data/ui/window.ui:550
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Verwische Zerstreuungskreis"
 
-#: data/ui/window.ui:572
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Benutzerdefinierte Farbe verwenden"
 
-#: data/ui/window.ui:573
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "HDRI Hintergrund hat höhere Priorität"
 
-#: data/ui/window.ui:580
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Hintegrundfarbe"
 
-#: data/ui/window.ui:581
-msgid "Transparent colors not supported"
-msgstr "Durchsichtige Farben werden nicht unterstützt"
-
-#: data/ui/window.ui:605
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Mehr"
 
-#: data/ui/window.ui:619
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Navigation"
 
-#: data/ui/window.ui:624
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr "Immer nach oben zeigen"
 
-#: data/ui/window.ui:631
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Aufwärtsrichtung"
 
-#: data/ui/window.ui:632
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "Diese Änderung wird die Datei neuladen"
 
-#: data/ui/window.ui:636
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr "- X"
 
-#: data/ui/window.ui:637
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr "+ X"
 
-#: data/ui/window.ui:638
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr "- Y"
 
-#: data/ui/window.ui:639
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr "+ Y"
 
-#: data/ui/window.ui:640
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr "- Z"
 
-#: data/ui/window.ui:641
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr "+ Z"
 
-#: data/ui/window.ui:653
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Navigation"
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
 msgid "Loading"
 msgstr "Lade"
 
-#: data/ui/window.ui:658
+#: data/ui/window.ui:761
 msgid "Automatic Settings"
 msgstr "Automatische Einstellungen"
 
-#: data/ui/window.ui:659
+#: data/ui/window.ui:762
 msgid "When loading choose the best presets for the file"
 msgstr "Beim Laden die beste Voreinstellung für Datei verwenden"
 
-#: data/ui/window.ui:672
+#: data/ui/window.ui:775
 msgid "Reload On Change"
 msgstr "Bei Änderung neuladen"
 
-#: data/ui/window.ui:673
+#: data/ui/window.ui:776
 msgid "Check for file change"
 msgstr "Auf Dateiänderungen prüfen"
 
-#: data/ui/window.ui:702
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "Seitenleiste anzeigen"
 
-#: data/ui/window.ui:728
-msgid "Toggle Orthographic"
-msgstr "Orthographisch wechseln"
-
-#: data/ui/window.ui:736
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr "Auf Ursprung zurücksetzten"
 
-#: data/ui/window.ui:798
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "Systemthema"
 
-#: data/ui/window.ui:803
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "Helles Thema"
 
-#: data/ui/window.ui:808
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "Dunkles Thema"
 
-#: data/ui/window.ui:813 data/ui/window.ui:863
+#: data/ui/window.ui:926 data/ui/window.ui:990
 msgid "_New Window"
 msgstr "_Neues Fenster"
 
-#: data/ui/window.ui:819
+#: data/ui/window.ui:930
 msgid "_Load New File"
 msgstr "_Neue Datei laden"
 
-#: data/ui/window.ui:825
+#: data/ui/window.ui:938
 msgid "_Export Image"
 msgstr "_Bild exportieren"
 
-#: data/ui/window.ui:831 data/ui/window.ui:869
+#: data/ui/window.ui:942
+#, fuzzy
+#| msgid "Open With External App"
+msgid "_Open In External App"
+msgstr "In externer Anwendung öffnen"
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: data/ui/window.ui:835 data/ui/window.ui:873
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "_Tastenkürzel"
 
-#: data/ui/window.ui:839 data/ui/window.ui:877
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr "_Über Austellung"
 
-#: data/ui/window.ui:849
+#: data/ui/window.ui:966
 msgid "Save Current Settings"
 msgstr "Aktuelle Einstellungen speichern"
 
-#: data/ui/window.ui:855
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Orthographisch wechseln"
+
+#: data/ui/window.ui:978
 msgid "Open HDRI Folder"
 msgstr "HDRI Ordner öffnen"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open HDRI Folder"
+msgid "Open HDRI"
+msgstr "HDRI Ordner öffnen"
+
+#~ msgid "Nissan Fairlady with dark theme"
+#~ msgstr "Nissan Fairlady im dunklem Thema"
+
+#~ msgid "Load type"
+#~ msgstr "Ladetyp"
+
+#~ msgid "Geometry"
+#~ msgstr "Gemoetrie"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "Durchsichtige Farben werden nicht unterstützt"

--- a/po/es.po
+++ b/po/es.po
@@ -1,15 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Spanish translation.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
+# haggen88, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-04 15:16+0200\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-09-22 11:39-0300\n"
-"Last-Translator: \n"
+"Last-Translator: haggen88\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -17,21 +17,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:848
-#: data/ui/window.ui:11 data/ui/window.ui:77 data/ui/window.ui:155
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Exhibit"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "Visor de modelos 3D"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+#, fuzzy
+#| msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:73
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Previsualice sus modelos 3D"
 
@@ -54,374 +57,470 @@ msgstr ""
 "el render perfecto. Puede utilizar una imagen HDRI o un color personalizado "
 "como fondo."
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "3D Bechy"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#, fuzzy
+#| msgid "3D Bechy"
+msgid "3D Benchy"
 msgstr "3D Bechy"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
 msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Configuración de ordenador retro con un skybox HDRI"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
 msgid "Green Metallic Suzanne"
 msgstr "Verde metalizado Suzanne"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
 msgid "Cow with an HDRI background and dark theme"
 msgstr "Vaca con fondo HDRI y tema oscuro"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:58
-msgid "Nissan Fairlady with dark theme"
-msgstr "Nissan Fairlady con tema oscuro"
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:62
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
 msgid "Vase 3d scan with HDRI skybox"
 msgstr "Jarrón escaneado en 3D con skybox HDRI"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
 msgid "Point cloud of a boat with dark theme"
 msgstr "Nube de puntos de un barco con tema oscuro"
 
-#: src/main.py:140
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Point cloud of a boat with dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Nube de puntos de un barco con tema oscuro"
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr "Comprobar F3D"
 
-#: src/window.py:713
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Abrir archivo"
 
-#: src/window.py:853
+#: src/window.py:847
+#, fuzzy
+#| msgid "Loading"
+msgid "Loading {}"
+msgstr "Cargando"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Exhibit"
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr "No se puede abrir"
 
-#: src/window.py:869
+#: src/window.py:958
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: data/ui/window.ui:49 data/ui/window.ui:178 data/ui/window.ui:185
-#: data/ui/window.ui:711
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
+
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Menú"
 
-#: data/ui/window.ui:69
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Cargar"
 
-#: data/ui/window.ui:95
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr "Pruebe otro"
 
-#: data/ui/window.ui:99
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr "No se ha podido cargar el archivo"
 
-#: data/ui/window.ui:103
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "Error al cargar el archivo"
 
-#: data/ui/window.ui:161 data/ui/window.ui:719
-msgid "Open With External App"
-msgstr "Abrir con aplicación externa"
-
-#: data/ui/window.ui:171
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "Cerrar barra lateral"
 
-#: data/ui/window.ui:208
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Renderizar"
 
-#: data/ui/window.ui:222
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "Renderizando"
 
-#: data/ui/window.ui:227
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "Translucidez"
 
-#: data/ui/window.ui:234
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "Mapeo de tonos"
 
-#: data/ui/window.ui:235
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "Asignar colores correctamente a los colores del monitor"
 
-#: data/ui/window.ui:242
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "Oclusión ambiental"
 
-#: data/ui/window.ui:243
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "Proporciona sombras aproximadas"
 
-#: data/ui/window.ui:250
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "Anti Aliasing"
 
-#: data/ui/window.ui:257
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "Iluminación con HDRI"
 
-#: data/ui/window.ui:258
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr "Ilumina la escena utilizando una HDRI cargada o la predeterminada"
 
-#: data/ui/window.ui:273
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "Intensidad luminosa"
 
-#: data/ui/window.ui:282
+#: data/ui/window.ui:327
 msgid "Model Rendering"
 msgstr "Renderizado de modelos"
 
-#: data/ui/window.ui:287
+#: data/ui/window.ui:332
 msgid "Show All Edges"
 msgstr "Mostrar todos los bordes"
 
-#: data/ui/window.ui:294
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Anchura de los bordes"
 
-#: data/ui/window.ui:316
-msgid "Show Spheres"
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Points"
+msgid "Show Point Sprites"
+msgstr "Mostrar puntos"
+
+#: data/ui/window.ui:364
+#, fuzzy
+#| msgid "Points Size"
+msgid "Point Sprites Type"
+msgstr "Tamaño de puntos"
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Sphere"
 msgstr "Mostrar esferas"
 
-#: data/ui/window.ui:323
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+#, fuzzy
+#| msgid "Points Size"
+msgid "Sprite Size"
+msgstr "Tamaño de puntos"
+
+#: data/ui/window.ui:390
 msgid "Points Size"
 msgstr "Tamaño de puntos"
 
-#: data/ui/window.ui:347 data/ui/window.ui:361
+#: data/ui/window.ui:413
 msgid "Model"
 msgstr "Modelo"
 
-#: data/ui/window.ui:367
-msgid "Load type"
-msgstr "Tipo de carga"
-
-#: data/ui/window.ui:371
-msgid "Geometry"
-msgstr "Geometría"
-
-#: data/ui/window.ui:372 data/ui/window.ui:488
-msgid "Scene"
-msgstr "Escena"
-
-#: data/ui/window.ui:385
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "Material"
 
-#: data/ui/window.ui:390
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "Modelo metálico"
 
-#: data/ui/window.ui:406
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "Rugosidad del modelo"
 
-#: data/ui/window.ui:423
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "Opacidad del modelo"
 
-#: data/ui/window.ui:441
+#: data/ui/window.ui:483
 msgid "Color"
 msgstr "Color"
 
-#: data/ui/window.ui:447
+#: data/ui/window.ui:489
 msgid "Coloration"
 msgstr "Coloración"
 
-#: data/ui/window.ui:451
+#: data/ui/window.ui:493
 msgid "Custom"
 msgstr "Personalizado"
 
-#: data/ui/window.ui:452
+#: data/ui/window.ui:494
 msgid "Normal"
 msgstr "Normal"
 
-#: data/ui/window.ui:453
+#: data/ui/window.ui:495
 msgid "Magnitude"
 msgstr "Magnitud"
 
-#: data/ui/window.ui:454
+#: data/ui/window.ui:496
 msgid "Direct"
 msgstr "Directo"
 
-#: data/ui/window.ui:464
+#: data/ui/window.ui:506 data/ui/window.ui:513
 msgid "Model Color"
 msgstr "Color del modelo"
 
-#: data/ui/window.ui:502
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "Escena"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Cuadrícula"
 
-#: data/ui/window.ui:507
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Ver cuadrícula"
 
-#: data/ui/window.ui:514
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Cuadrícula Absoluta"
 
-#: data/ui/window.ui:523
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Fondo"
 
-#: data/ui/window.ui:528
+#: data/ui/window.ui:582
 msgid "HDRI as Background"
 msgstr "HDRI como fondo"
 
-#: data/ui/window.ui:529
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Utilizar la HDRI cargada o la predeterminada como fondo"
 
-#: data/ui/window.ui:536
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "Imagen HDRI"
 
-#: data/ui/window.ui:543
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Desenfoque de fondo"
 
-#: data/ui/window.ui:550
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Círculo borroso de confusión"
 
-#: data/ui/window.ui:572
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Usar color personalizado"
 
-#: data/ui/window.ui:573
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "El fondo HDRI tiene prioridad sobre este"
 
-#: data/ui/window.ui:580
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Color de fondo"
 
-#: data/ui/window.ui:581
-msgid "Transparent colors not supported"
-msgstr "No se admiten colores transparentes"
-
-#: data/ui/window.ui:605
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Más"
 
-#: data/ui/window.ui:619
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Navegación"
 
-#: data/ui/window.ui:624
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr "Apunta siempre hacia arriba"
 
-#: data/ui/window.ui:631
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Dirección ascendente"
 
-#: data/ui/window.ui:632
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "Si lo cambia, se volverá a cargar el archivo"
 
-#: data/ui/window.ui:636
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr "- X"
 
-#: data/ui/window.ui:637
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr "+ X"
 
-#: data/ui/window.ui:638
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr "- Y"
 
-#: data/ui/window.ui:639
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr "+ Y"
 
-#: data/ui/window.ui:640
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr "- Z"
 
-#: data/ui/window.ui:641
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr "+ Z"
 
-#: data/ui/window.ui:653
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Navegación"
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
 msgid "Loading"
 msgstr "Cargando"
 
-#: data/ui/window.ui:658
+#: data/ui/window.ui:761
 msgid "Automatic Settings"
 msgstr "Configuración automática"
 
-#: data/ui/window.ui:659
+#: data/ui/window.ui:762
 msgid "When loading choose the best presets for the file"
 msgstr "Al cargar, elija los mejores ajustes preestablecidos para el archivo"
 
-#: data/ui/window.ui:672
+#: data/ui/window.ui:775
 msgid "Reload On Change"
 msgstr "Recargar al cambiar"
 
-#: data/ui/window.ui:673
+#: data/ui/window.ui:776
 msgid "Check for file change"
 msgstr "Comprobar cambios de archivos"
 
-#: data/ui/window.ui:702
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "Mostrar barra lateral"
 
-#: data/ui/window.ui:728
-msgid "Toggle Orthographic"
-msgstr "Conmutar ortográfico"
-
-#: data/ui/window.ui:736
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr "Restablecer límites"
 
-#: data/ui/window.ui:798
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "Seguir el estilo del sistema"
 
-#: data/ui/window.ui:803
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "Tema claro"
 
-#: data/ui/window.ui:808
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "Tema oscuro"
 
-#: data/ui/window.ui:813 data/ui/window.ui:863
+#: data/ui/window.ui:926 data/ui/window.ui:990
 msgid "_New Window"
 msgstr "_Nueva ventana"
 
-#: data/ui/window.ui:819
+#: data/ui/window.ui:930
 msgid "_Load New File"
 msgstr "_Cargar nuevo archivo"
 
-#: data/ui/window.ui:825
+#: data/ui/window.ui:938
 msgid "_Export Image"
 msgstr "_Exportar imagen"
 
-#: data/ui/window.ui:831 data/ui/window.ui:869
+#: data/ui/window.ui:942
+#, fuzzy
+#| msgid "Open With External App"
+msgid "_Open In External App"
+msgstr "Abrir con aplicación externa"
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
 msgid "_Help"
 msgstr "_Ayuda"
 
-#: data/ui/window.ui:835 data/ui/window.ui:873
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "_Atajos de teclado"
 
-#: data/ui/window.ui:839 data/ui/window.ui:877
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr "_Acerca de Exhibit"
 
-#: data/ui/window.ui:849
+#: data/ui/window.ui:966
 msgid "Save Current Settings"
 msgstr "Guardar configuración actual"
 
-#: data/ui/window.ui:855
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Conmutar ortográfico"
+
+#: data/ui/window.ui:978
 msgid "Open HDRI Folder"
 msgstr "Abrir carpeta HDRI"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open HDRI Folder"
+msgid "Open HDRI"
+msgstr "Abrir carpeta HDRI"
+
+#~ msgid "Nissan Fairlady with dark theme"
+#~ msgstr "Nissan Fairlady con tema oscuro"
+
+#~ msgid "Load type"
+#~ msgstr "Tipo de carga"
+
+#~ msgid "Geometry"
+#~ msgstr "Geometría"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "No se admiten colores transparentes"
 
 #~ msgid "Sailing Ship 3d scan rendered as points"
 #~ msgstr "Escaneo 3D del velero representado como puntos"
@@ -431,9 +530,6 @@ msgstr "Abrir carpeta HDRI"
 
 #~ msgid "Planetary Reducer"
 #~ msgstr "Reductor planetario"
-
-#~ msgid "Show Points"
-#~ msgstr "Mostrar puntos"
 
 #~ msgid "Other Settings"
 #~ msgstr "Otros ajustes"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,378 +1,488 @@
-# FRENCH TRANSLATION.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# French translation.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
+# Thibautplg <>, 2024.
+# Mimolet <themimolet@proton.me>, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-30 20:41+0200\n"
-"PO-Revision-Date: 2024-06-30 20:41+0200\n"
-"Last-Translator: Thibautplg\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
+"PO-Revision-Date: 2026-02-26 22:16+0100\n"
+"Last-Translator: Mimolet <theMimolet@proton.me>\n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Gtranslator 49.0\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 data/window.ui:20
-#: data/window.ui:84
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Exhibit"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "Visionneur de modèle 3D"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr ""
+"fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;rendu;3d-"
+"model;modèle;modèle-3d;3d-viewer;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:80
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Prévisualisez vos modèles 3D"
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:10
 msgid ""
-"Based on the F3D library that supports many file formats, from digital "
-"content to scientific datasets including glTF, USD, STL, STEP, PLY, OBJ, "
-"FBX, Alembic and many more. Drag and drop 3d models into the app and export "
-"an image of the 3d model. It supports tone mapping, ambient occlusion, anti "
-"aliasing and more. You can use an HDRI image or a custom color as a "
-"background."
+"Based on the F3D library, it supports many file formats, from digital "
+"content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
+"USD, Alembic and many more. You can drag and drop 3d models into the app and "
+"export an image of the rendered model. Change many settings like tone "
+"mapping, ambient occlusion, anti aliasing, material roughness, metallic, "
+"color and opacity to achieve the perfect render. You can use an HDRI image "
+"or a custom color as a background."
 msgstr ""
-"Basé sur la bibliothèque F3D qui prend en charge de nombreux formats de fichiers, du "
-"contenu numérique aux ensembles de données scientifiques tels que glTF, USD, STL, STEP, PLY, OBJ, "
-"FBX, Alembic et bien d'autres. Glissez-déposez les modèles 3D dans l'application et exportez "
-"une image du modèle 3D. Exhibit prend en charge la correspondance tonale, l'occlusion ambiante, l' "
-"anti-crénelage et bien plus encore. Vous pouvez utiliser une image HDRI ou une couleur personnalisée comme "
-"arrière-plan."
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "Planetary Reducer"
-msgstr "Réducteur planétaire"
+"Basé sur la bibliothèque F3D qui prend en charge de nombreux formats de "
+"fichiers, du contenu numérique aux ensembles de données scientifiques tels "
+"que glTF, USD, STL, STEP, PLY, OBJ, FBX, Alembic et bien d'autres. Glissez-"
+"déposez les modèles 3D dans l'application et exportez une image du modèle "
+"3D. Exhibit prend en charge la correspondance tonale, l'occlusion ambiante, "
+"l' anti-crénelage et bien plus encore. Vous pouvez utiliser une image HDRI "
+"ou une couleur personnalisée comme arrière-plan."
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
-msgid "Nissan Fairlady"
-msgstr ""
+msgid "3D Benchy"
+msgstr "Aperçu du bateau Benchy en 3D "
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
-msgid "Retro Computer Setup with a HDRI background"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
+msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Ordinateur vintage avec un fond HDRI"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
-msgid "Benchy with dark theme"
-msgstr "Benchy avec le thème sombre"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
+msgid "Green Metallic Suzanne"
+msgstr "Suzanne en métal vert"
 
-#: src/main.py:104
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
+msgid "Cow with an HDRI background and dark theme"
+msgstr "Vache avec un arrière-plan HDRI et un thème sombre"
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+msgid "Vase 3d scan with HDRI skybox"
+msgstr "Scan 3D d'un vase avec skybox HDRI"
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
+msgid "Point cloud of a boat with dark theme"
+msgstr "Nuage de points d'un bateau avec thème sombre"
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+msgid "Rigged model showing armature with dark theme"
+msgstr "Modèle avec Rig montrant une armature avec un thème sombre"
+
+#: src/main.py:129
 msgid "Checkout F3D"
-msgstr "Vérifier F3D"
+msgstr "Découvrez F3D"
 
-#: src/window.py:478
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr "Faire un don avec Ko-Fi"
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr "Faire un don avec Github"
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr "Tous les formats pris en charge"
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Ouvrir un fichier"
 
-#: src/window.py:582
-msgid "Can't open "
+#: src/window.py:847
+msgid "Loading {}"
+msgstr "Chargement de {}"
+
+#: src/window.py:917
+msgid "Exhibit - {}"
+msgstr "Exhibit - {}"
+
+#: src/window.py:942
+msgid "Can't open"
 msgstr "Ouverture impossible"
 
-#: src/window.py:607
+#: src/window.py:958
 msgid "Save File"
 msgstr "Sauvegarder le fichier"
 
-#: src/window.py:801
-msgid "Open Skybox File"
-msgstr "Ouvrir un fichier Skybox"
+#: src/window.py:1065
+msgid "Stop"
+msgstr "Arrêter"
 
-#: data/ui/window.ui:46 data/ui/window.ui:176 data/ui/window.ui:715
+#: src/window.py:1068
+msgid "Start"
+msgstr "Démarrer"
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Menu"
 
-#: data/window.ui:76
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Ouvrir"
 
-#: data/ui/window.ui:100
-msgid "Essayer un autre fichier"
-msgstr ""
+#: data/ui/window.ui:110
+msgid "Try Another"
+msgstr "Essayer un autre"
 
-#: data/ui/window.ui:104
-msgid "Chargement du fichier impossible"
-msgstr ""
+#: data/ui/window.ui:114
+msgid "Couldn't load the file"
+msgstr "Échec du chargement du fichier"
 
-#: data/ui/window.ui:108
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "Erreur pendant le chargement du fichier"
 
-#: data/ui/window.ui:167
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "Fermer la barre latérale"
 
-#: data/ui/window.ui:198 data/ui/window.ui:212
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Rendu"
 
-#: data/ui/window.ui:217
-msgid "Translucency"
-msgstr "Translucence"
-
-#: data/ui/window.ui:224
-msgid "Tone Mapping"
-msgstr "Correspondance tonale"
-
-#: data/ui/window.ui:225
-msgid "Map colors properly to the monitor colors"
-msgstr "Faire correspondre les couleurs à celles de l'écran"
-
-#: data/ui/window.ui:232
-msgid "Ambient Occlusion"
-msgstr "Occlusion ambiante"
-
-#: data/ui/window.ui:233
-msgid "Provides approximate shadows"
-msgstr "Affiche des ombres approximatives"
-
-#: data/ui/window.ui:240
-msgid "Anti Aliasing"
-msgstr "Anti-crénelage"
-
-#: data/ui/window.ui:247
-msgid "Light with HDRI"
-msgstr "Lumière avec HDRI"
-
-#: data/ui/window.ui:248
-msgid "Light the scene using a the loaded HDRI or the default"
-msgstr "Illuminer la scène en utilisant le HDRI chargé ou celui par défaut"
-
-#: data/ui/window.ui:263
-msgid "Light Intensity"
-msgstr "Intensité lumineuse"
-
-#: data/ui/window.ui:278 data/ui/window.ui:292
-msgid "Model"
-msgstr "Modèle"
-
-#: data/ui/window.ui:298
-msgid "Load type"
-msgstr "Type de chargement"
-
-#: data/ui/window.ui:302
-msgid "Geometry"
-msgstr "Géométrie"
-
-#: data/ui/window.ui:303 data/ui/window.ui:459
-msgid "Scene"
-msgstr ""
-
-#: data/ui/window.ui:315
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "Rendu"
 
-#: data/ui/window.ui:322
-msgid "Show Edges"
-msgstr "Montrer les bordures"
+#: data/ui/window.ui:272
+msgid "Translucency"
+msgstr "Translucence"
 
-#: data/ui/window.ui:328
+#: data/ui/window.ui:279
+msgid "Tone Mapping"
+msgstr "Correspondance tonale"
+
+#: data/ui/window.ui:280
+msgid "Map colors properly to the monitor colors"
+msgstr "Faire correspondre les couleurs à celles de l'écran"
+
+#: data/ui/window.ui:287
+msgid "Ambient Occlusion"
+msgstr "Occlusion ambiante"
+
+#: data/ui/window.ui:288
+msgid "Provides approximate shadows"
+msgstr "Affiche des ombres approximatives"
+
+#: data/ui/window.ui:295
+msgid "Anti Aliasing"
+msgstr "Anti-crénelage"
+
+#: data/ui/window.ui:302
+msgid "Light with HDRI"
+msgstr "Lumière avec HDRI"
+
+#: data/ui/window.ui:303
+msgid "Light the scene using a the loaded HDRI or the default"
+msgstr "Illuminer la scène en utilisant le HDRI chargé ou celui par défaut"
+
+#: data/ui/window.ui:318
+msgid "Light Intensity"
+msgstr "Intensité lumineuse"
+
+#: data/ui/window.ui:327
+msgid "Model Rendering"
+msgstr "Rendu du modèle"
+
+#: data/ui/window.ui:332
+msgid "Show All Edges"
+msgstr "Afficher les bordures"
+
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Largeur des bordures"
 
-#: data/ui/window.ui:353
-msgid "Show Points"
-msgstr "Voir les points"
-
 #: data/ui/window.ui:359
-msgid "Points Radius"
-msgstr "Rayon de point"
+msgid "Show Point Sprites"
+msgstr "Afficher des sprites de point"
 
-#: data/ui/window.ui:378
+#: data/ui/window.ui:364
+msgid "Point Sprites Type"
+msgstr "Types de sprites de point"
+
+#: data/ui/window.ui:368
+msgid "Sphere"
+msgstr "Sphère"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr "Gaussien"
+
+#: data/ui/window.ui:377
+msgid "Sprite Size"
+msgstr "Taille des sprites"
+
+#: data/ui/window.ui:390
+msgid "Points Size"
+msgstr "Taille des points"
+
+#: data/ui/window.ui:413
+msgid "Model"
+msgstr "Modèle"
+
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "Matériaux"
 
-#: data/ui/window.ui:383
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "Aspect métalique"
 
-#: data/ui/window.ui:400
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "Rugosité du modèle"
 
-#: data/ui/window.ui:417
-msgid "Model Color"
-msgstr "Couleur du modèle"
-
-#: data/ui/window.ui:433
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "Opacité du modèle"
 
-#: data/ui/window.ui:473
+#: data/ui/window.ui:483
+msgid "Color"
+msgstr "Couleur"
+
+#: data/ui/window.ui:489
+msgid "Coloration"
+msgstr "Coloration"
+
+#: data/ui/window.ui:493
+msgid "Custom"
+msgstr "Personnalisé"
+
+#: data/ui/window.ui:494
+msgid "Normal"
+msgstr "Normale"
+
+#: data/ui/window.ui:495
+msgid "Magnitude"
+msgstr "Magnitude"
+
+#: data/ui/window.ui:496
+msgid "Direct"
+msgstr "Direct"
+
+#: data/ui/window.ui:506 data/ui/window.ui:513
+msgid "Model Color"
+msgstr "Couleur du modèle"
+
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr "Afficher l'armature"
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "Scène"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Grille"
 
-#: data/ui/window.ui:478
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Voir la grille"
 
-#: data/ui/window.ui:485
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Grille absolue"
 
-#: data/ui/window.ui:494
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Arrière plan"
 
-#: data/ui/window.ui:499
-msgid "HDRI as Backgound"
-msgstr "HDRI en temps qu'arrière plan"
+#: data/ui/window.ui:582
+msgid "HDRI as Background"
+msgstr "HDRI comme qu'arrière plan"
 
-#: data/ui/window.ui:500
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Utiliser le HDRI chargé ou celui par défaut en temps qu'arrière plan"
 
-#: data/ui/window.ui:507
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "Image HDRI"
 
-#: data/ui/window.ui:514
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Flouter l'arrière plan"
 
-#: data/ui/window.ui:521
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Flouter le cercle de confusion"
 
-#: data/ui/window.ui:543
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Utiliser une couleur personnalisée"
 
-#: data/ui/window.ui:544
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "L'arrière plan HDRI prend le dessus là dessus"
 
-#: data/ui/window.ui:551
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Couleur d'arrière plan"
 
-#: data/ui/window.ui:552
-msgid "Transparent colors not supported"
-msgstr "Les couleurs transparentes ne sont pas supportées"
-
-#: data/ui/window.ui:576
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Plus"
 
-#: data/ui/window.ui:590
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Navigation"
 
-#: data/ui/window.ui:595
-msgid "Alwayas Point Up"
-msgstr "Toujours pointer en haut"
+#: data/ui/window.ui:680
+msgid "Always Point Up"
+msgstr "Toujours pointer vers le haut"
 
-#: data/ui/window.ui:602
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Orientation du haut"
 
-#: data/ui/window.ui:603
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "Le modifier rechargera le fichier"
 
-#: data/ui/window.ui:607
+#: data/ui/window.ui:692
 msgid "- X"
-msgstr ""
+msgstr "- X"
 
-#: data/ui/window.ui:608
+#: data/ui/window.ui:693
 msgid "+ X"
-msgstr ""
+msgstr "+ X"
 
-#: data/ui/window.ui:609
+#: data/ui/window.ui:694
 msgid "- Y"
-msgstr ""
+msgstr "- Y"
 
-#: data/ui/window.ui:610
+#: data/ui/window.ui:695
 msgid "+ Y"
-msgstr ""
+msgstr "+ Y"
 
-#: data/ui/window.ui:611
+#: data/ui/window.ui:696
 msgid "- Z"
-msgstr ""
+msgstr "- Z"
 
-#: data/ui/window.ui:612
+#: data/ui/window.ui:697
 msgid "+ Z"
+msgstr "+ Z"
+
+#: data/ui/window.ui:707
+msgid "Animation"
+msgstr "Animation"
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr "Index de l'animation"
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr "Jouer"
+
+#: data/ui/window.ui:756
+msgid "Loading"
+msgstr "Chargement"
+
+#: data/ui/window.ui:761
+msgid "Automatic Settings"
+msgstr "Règlages automatiques"
+
+#: data/ui/window.ui:762
+msgid "When loading choose the best presets for the file"
 msgstr ""
+"Lors du chargement, choisissez les meilleurs préréglages pour le fichier."
 
-#: data/ui/window.ui:624
-msgid "Other Settings"
-msgstr "Autres paramètres"
+#: data/ui/window.ui:775
+msgid "Reload On Change"
+msgstr "Recharger à la modification"
 
-#: data/ui/window.ui:629
-msgid "Automatic Up Direction"
-msgstr "Orientation du haut automatique "
+#: data/ui/window.ui:776
+msgid "Check for file change"
+msgstr "Détecte des changements sur le fichier"
 
-#: data/ui/window.ui:630
-msgid "When loading choose the best up direction"
-msgstr "Lors du chargement, détecter la meilleure orientation"
-
-#: data/ui/window.ui:637
-msgid "Save Settings"
-msgstr "Sauvegarder les paramètres"
-
-#: data/ui/window.ui:647
-msgid "Restore Settings"
-msgstr "Restaurer les paramètres"
-
-#: data/ui/window.ui:663
-msgid "Reset Settings"
-msgstr "Réinitialiser les paramètres"
-
-#: data/ui/window.ui:672
-msgid ""
-"Preferences are per window basis, if you save them next time you will open "
-"the app it will start with these preferences"
-msgstr ""
-"Les préférences se font par fenêtre, si sauvegardées, la prochaine ouverture de "
-"l'application démarrera avec ces préférences"
-
-#: data/ui/window.ui:708
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "Afficher la barre latérale"
 
-#: data/window.ui:27
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
-msgstr "Réinitialiser les limites"
+msgstr "Réinitialiser aux limites"
 
-#: data/window.ui:35
-msgid "Toggle Orthographic"
-msgstr "Activer/Désactiver la vue ortographique"
-
-#: data/ui/window.ui:818
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "Comme le système"
 
-#: data/ui/window.ui:823
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "Thème clair"
 
-#: data/ui/window.ui:828
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "Thème sombre"
 
-#: data/ui/window.ui:833 data/ui/window.ui:863
-msgid "_Open New Window"
-msgstr "_Ouvrir une nouvelle fenêtre"
+#: data/ui/window.ui:926 data/ui/window.ui:990
+msgid "_New Window"
+msgstr "Ouvrir une _nouvelle fenêtre"
 
-#: data/ui/window.ui:839
-msgid "_Load"
-msgstr "_Ouvrir"
+#: data/ui/window.ui:930
+msgid "_Load New File"
+msgstr "_Charger un nouveau fichier"
 
-#: data/ui/window.ui:845
-msgid "_Save As Image"
-msgstr "_Enregistrer en temps qu'image"
+#: data/ui/window.ui:938
+msgid "_Export Image"
+msgstr "_Exporter l'image"
 
-#: data/ui/window.ui:851 data/ui/window.ui:869
+#: data/ui/window.ui:942
+msgid "_Open In External App"
+msgstr "Ouvrir dans une application _externe"
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
+msgid "_Help"
+msgstr "_Aide"
+
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "_Raccourcis clavier"
 
-#: data/ui/window.ui:855 data/ui/window.ui:873
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
-msgstr "_À propos de Exhibit"
+msgstr "À _propos de Exhibit"
+
+#: data/ui/window.ui:966
+msgid "Save Current Settings"
+msgstr "Sauvegarder les paramètres actuels"
+
+#: data/ui/window.ui:972
+msgid "Orthonographic"
+msgstr "Vue ortographique"
+
+#: data/ui/window.ui:978
+msgid "Open HDRI Folder"
+msgstr "Ouvrir le dossier HDRI"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr "Ouvrir le dossier de configuration"
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr "Liste séparée par virgules des extensions prises en charge"
+
+#: data/ui/file_row.ui:83
+msgid "Open HDRI"
+msgstr "Ouvrir un fichier HDRI"

--- a/po/hi.po
+++ b/po/hi.po
@@ -1,13 +1,13 @@
 # Hindi translation for exhibit.
-# Copyright (C) 2024 exhibit's COPYRIGHT HOLDER
-# This file is distributed under the same license as the exhibit package.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
 # Scrambled777 <weblate.scrambled777@simplelogin.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: exhibit\n"
-"Report-Msgid-Bugs-To: https://github.com/Nokse22/Exhibit/issues\n"
-"POT-Creation-Date: 2024-07-29 23:06+0200\n"
+"Project-Id-Version: Exhibit\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-08-03 00:10+0530\n"
 "Last-Translator: Scrambled777 <weblate.scrambled777@simplelogin.com>\n"
 "Language-Team: Hindi <indlinux-hindi@lists.sourceforge.net>\n"
@@ -18,27 +18,39 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Gtranslator 46.1\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:843
-#: data/ui/window.ui:11 data/ui/window.ui:77 data/ui/window.ui:156
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "एक्ज़िबिट"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "3डी मॉडल दर्शक"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+#, fuzzy
+#| msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr "fbx;कदम;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;प्रतिपादन;3डी-मॉडल;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:73
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "अपने 3डी मॉडल का पूर्वावलोकन करें"
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:10
+#, fuzzy
+#| msgid ""
+#| "Based on the F3D library that supports many file formats, from digital "
+#| "content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
+#| "USD, Alembic and many more. You can drag and drop 3d models into the app "
+#| "and export an image of the rendered model. Change many settings like tone "
+#| "mapping, ambient occlusion, anti aliasing, material roughness, metallic, "
+#| "color and opacity to achieve the perfect render. You can use an HDRI "
+#| "image or a custom color as a background."
 msgid ""
-"Based on the F3D library that supports many file formats, from digital "
+"Based on the F3D library, it supports many file formats, from digital "
 "content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
 "USD, Alembic and many more. You can drag and drop 3d models into the app and "
 "export an image of the rendered model. Change many settings like tone "
@@ -53,371 +65,473 @@ msgstr ""
 "एंटी एलियासिंग, मटेरियल रफनेस, मेटैलिक, रंग और अपारदर्शिता जैसी कई सेटिंग बदलें। पृष्ठभूमि के "
 "रूप में एचडीआरआई छवि या तदनुकूल रंग का उपयोग कर सकते हैं।"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "Bechy"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#, fuzzy
+#| msgid "Bechy"
+msgid "3D Benchy"
 msgstr "बीचि"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
-msgid "Retro Computer Setup with a HDRI background"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
+#, fuzzy
+#| msgid "Retro Computer Setup with a HDRI background"
+msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "एचडीआरआई पृष्ठभूमि के साथ रेट्रो कंप्यूटर सेटअप"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
 msgid "Green Metallic Suzanne"
 msgstr "ग्रीन मेटैलिक सुज़ैन"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
-msgid "Cow with a HDRI background in dark theme"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
+#, fuzzy
+#| msgid "Cow with a HDRI background in dark theme"
+msgid "Cow with an HDRI background and dark theme"
 msgstr "गहरे रंग की थीम में एचडीआरआई पृष्ठभूमि वाली गाय"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:58
-msgid "Nissan Fairlady in dark theme"
-msgstr "गहरे रंग की थीम में निसान फेयरलेडी"
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:62
-msgid "Vase 3d scan with HDRI"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+#, fuzzy
+#| msgid "Vase 3d scan with HDRI"
+msgid "Vase 3d scan with HDRI skybox"
 msgstr "एचडीआरआई के साथ फूलदान 3डी स्कैन"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
-msgid "Sailing Ship 3d scan rendered as points"
-msgstr "नौकायन जहाज 3डी स्कैन को बिंदुओं के रूप में प्रतिपादन किया गया"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
+msgid "Point cloud of a boat with dark theme"
+msgstr ""
 
-#: src/main.py:127
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Nissan Fairlady in dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "गहरे रंग की थीम में निसान फेयरलेडी"
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr "एफ3डी चेकआउट करें"
 
-#: src/window.py:711
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "फाइल खोलें"
 
-#: src/window.py:848
+#: src/window.py:847
+#, fuzzy
+#| msgid "Loading"
+msgid "Loading {}"
+msgstr "लोड हो रहा है"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "एक्ज़िबिट"
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr "खोल नहीं सके"
 
-#: src/window.py:864
+#: src/window.py:958
 msgid "Save File"
 msgstr "फाइल सहेजें"
 
-#: data/ui/window.ui:49 data/ui/window.ui:179 data/ui/window.ui:186
-#: data/ui/window.ui:714
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
+
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "मेनू"
 
-#: data/ui/window.ui:69
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "लोड करें"
 
-#: data/ui/window.ui:96
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr "कोई दूसरा आज़माएं"
 
-#: data/ui/window.ui:100
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr "फाइल लोड नहीं की जा सकी"
 
-#: data/ui/window.ui:104
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "फाइल लोड करने में त्रुटि"
 
-#: data/ui/window.ui:162 data/ui/window.ui:722
-msgid "Open With External App"
-msgstr "बाहरी ऐप से खोलें"
-
-#: data/ui/window.ui:172
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "पार्श्वपट्टी बंद करें"
 
-#: data/ui/window.ui:209
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "प्रतिपादन करें"
 
-#: data/ui/window.ui:223
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "प्रतिपादन"
 
-#: data/ui/window.ui:228
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "पारदर्शता"
 
-#: data/ui/window.ui:235
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "टोन मैपिंग"
 
-#: data/ui/window.ui:236
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "रंगों को मॉनिटर के रंगों के साथ उचित रूप से मैप करें"
 
-#: data/ui/window.ui:243
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "परिवेशीय समावेशन"
 
-#: data/ui/window.ui:244
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "अनुमानित छायाएं प्रदान करता है"
 
-#: data/ui/window.ui:251
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "एंटी एलियासिंग"
 
-#: data/ui/window.ui:258
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "एचडीआरआई के साथ प्रकाश"
 
-#: data/ui/window.ui:259
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr "लोड किए गए एचडीआरआई या तयशुदा का उपयोग करके दृश्य को रोशन करें"
 
-#: data/ui/window.ui:274
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "प्रकाश तीव्रता"
 
-#: data/ui/window.ui:283
+#: data/ui/window.ui:327
 msgid "Model Rendering"
 msgstr "मॉडल प्रतिपादन"
 
-#: data/ui/window.ui:288
+#: data/ui/window.ui:332
 msgid "Show All Edges"
 msgstr "सभी किनारे दिखाएं"
 
-#: data/ui/window.ui:296
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "किनारों की चौड़ाई"
 
-#: data/ui/window.ui:318
-msgid "Show Spheres"
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Show Point Sprites"
 msgstr "गोले दिखाएं"
 
-#: data/ui/window.ui:326
+#: data/ui/window.ui:364
+#, fuzzy
+#| msgid "Points Size"
+msgid "Point Sprites Type"
+msgstr "बिंदु आकार"
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Sphere"
+msgstr "गोले दिखाएं"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+#, fuzzy
+#| msgid "Points Size"
+msgid "Sprite Size"
+msgstr "बिंदु आकार"
+
+#: data/ui/window.ui:390
 msgid "Points Size"
 msgstr "बिंदु आकार"
 
-#: data/ui/window.ui:350 data/ui/window.ui:364
+#: data/ui/window.ui:413
 msgid "Model"
 msgstr "मॉडल"
 
-#: data/ui/window.ui:370
-msgid "Load type"
-msgstr "लोड प्रकार"
-
-#: data/ui/window.ui:374
-msgid "Geometry"
-msgstr "ज्यामिति"
-
-#: data/ui/window.ui:375 data/ui/window.ui:491
-msgid "Scene"
-msgstr "दृश्य"
-
-#: data/ui/window.ui:388
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "सामग्री"
 
-#: data/ui/window.ui:393
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "मॉडल धात्विक"
 
-#: data/ui/window.ui:409
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "मॉडल खुरदरापन"
 
-#: data/ui/window.ui:426
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "मॉडल अपारदर्शिता"
 
-#: data/ui/window.ui:444
+#: data/ui/window.ui:483
 msgid "Color"
 msgstr "रंग"
 
-#: data/ui/window.ui:450
+#: data/ui/window.ui:489
 msgid "Coloration"
 msgstr "रंगाई"
 
-#: data/ui/window.ui:454
+#: data/ui/window.ui:493
 msgid "Custom"
 msgstr "तदनुकूल"
 
-#: data/ui/window.ui:455
+#: data/ui/window.ui:494
 msgid "Normal"
 msgstr "सामान्य"
 
-#: data/ui/window.ui:456
+#: data/ui/window.ui:495
 msgid "Magnitude"
 msgstr "परिमाण"
 
-#: data/ui/window.ui:457
+#: data/ui/window.ui:496
 msgid "Direct"
 msgstr "सीधे"
 
-#: data/ui/window.ui:467
+#: data/ui/window.ui:506 data/ui/window.ui:513
 msgid "Model Color"
 msgstr "मॉडल का रंग"
 
-#: data/ui/window.ui:505
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "दृश्य"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "ग्रिड"
 
-#: data/ui/window.ui:510
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "ग्रिड दृश्य"
 
-#: data/ui/window.ui:517
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "ग्रिड निरपेक्ष"
 
-#: data/ui/window.ui:526
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "पृष्ठभूमि"
 
-#: data/ui/window.ui:531
+#: data/ui/window.ui:582
 msgid "HDRI as Background"
 msgstr "पृष्ठभूमि के रूप में एचडीआरआई"
 
-#: data/ui/window.ui:532
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "लोड किए गए एचडीआरआई या तयशुदा को पृष्ठभूमि के रूप में उपयोग करें"
 
-#: data/ui/window.ui:539
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "एचडीआरआई छवि"
 
-#: data/ui/window.ui:546
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "पृष्ठभूमि धुंधला करें"
 
-#: data/ui/window.ui:553
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "भ्रांति घेरा को धुंधला करें"
 
-#: data/ui/window.ui:575
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "तदनुकूल रंग का प्रयोग करें"
 
-#: data/ui/window.ui:576
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "एचडीआरआई पृष्ठभूमि को इस पर वरीयता दी जाती है"
 
-#: data/ui/window.ui:583
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "पृष्ठभूमि रंग"
 
-#: data/ui/window.ui:584
-msgid "Transparent colors not supported"
-msgstr "पारदर्शी रंग समर्थित नहीं हैं"
-
-#: data/ui/window.ui:608
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "अधिक"
 
-#: data/ui/window.ui:622
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "पथ-प्रदर्शन"
 
-#: data/ui/window.ui:627
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr "हमेशा ऊपर इंगित करें"
 
-#: data/ui/window.ui:634
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "ऊपर की दिशा"
 
-#: data/ui/window.ui:635
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "इसे बदलने से फाइल पुनः लोड हो जाएगी"
 
-#: data/ui/window.ui:639
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr "- X"
 
-#: data/ui/window.ui:640
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr "+ X"
 
-#: data/ui/window.ui:641
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr "- Y"
 
-#: data/ui/window.ui:642
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr "+ Y"
 
-#: data/ui/window.ui:643
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr "- Z"
 
-#: data/ui/window.ui:644
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr "+ Z"
 
-#: data/ui/window.ui:656
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "पथ-प्रदर्शन"
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
 msgid "Loading"
 msgstr "लोड हो रहा है"
 
-#: data/ui/window.ui:661
+#: data/ui/window.ui:761
 msgid "Automatic Settings"
 msgstr "स्वचालित सेटिंग"
 
-#: data/ui/window.ui:662
+#: data/ui/window.ui:762
 msgid "When loading choose the best presets for the file"
 msgstr "लोड करते समय फाइल के लिए सर्वोत्तम प्रीसेट चुनें"
 
-#: data/ui/window.ui:675
+#: data/ui/window.ui:775
 msgid "Reload On Change"
 msgstr "बदलाव पर पुनः लोड करें"
 
-#: data/ui/window.ui:676
+#: data/ui/window.ui:776
 msgid "Check for file change"
 msgstr "फाइल बदलाव हेतु जांचें"
 
-#: data/ui/window.ui:705
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "पार्श्वपट्टी प्रकट करें"
 
-#: data/ui/window.ui:731
-msgid "Toggle Orthographic"
-msgstr "ऑर्थोग्राफ़िक टॉगल करें"
-
-#: data/ui/window.ui:739
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr "सीमाओं पर रीसेट करें"
 
-#: data/ui/window.ui:801
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "सिस्टम की पालना"
 
-#: data/ui/window.ui:806
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "हल्की थीम"
 
-#: data/ui/window.ui:811
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "गहरी थीम"
 
-#: data/ui/window.ui:816 data/ui/window.ui:866
+#: data/ui/window.ui:926 data/ui/window.ui:990
 msgid "_New Window"
 msgstr "नई विंडो (_N)"
 
-#: data/ui/window.ui:822
+#: data/ui/window.ui:930
 msgid "_Load New File"
 msgstr "नई फाइल लोड करें (_L)"
 
-#: data/ui/window.ui:828
+#: data/ui/window.ui:938
 msgid "_Export Image"
 msgstr "छवि निर्यात करें (_E)"
 
-#: data/ui/window.ui:834 data/ui/window.ui:872
+#: data/ui/window.ui:942
+#, fuzzy
+#| msgid "Open With External App"
+msgid "_Open In External App"
+msgstr "बाहरी ऐप से खोलें"
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
 msgid "_Help"
 msgstr "सहायता (_H)"
 
-#: data/ui/window.ui:838 data/ui/window.ui:876
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "कीबोर्ड शॉर्टकट (_K)"
 
-#: data/ui/window.ui:842 data/ui/window.ui:880
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr "एक्ज़िबिट का परिचय (_A)"
 
-#: data/ui/window.ui:852
+#: data/ui/window.ui:966
 msgid "Save Current Settings"
 msgstr "वर्तमान सेटिंग सहेजें"
 
-#: data/ui/window.ui:858
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "ऑर्थोग्राफ़िक टॉगल करें"
+
+#: data/ui/window.ui:978
 msgid "Open HDRI Folder"
 msgstr "एचडीआरआई फोल्डर खोलें"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open HDRI Folder"
+msgid "Open HDRI"
+msgstr "एचडीआरआई फोल्डर खोलें"
+
+#~ msgid "Load type"
+#~ msgstr "लोड प्रकार"
+
+#~ msgid "Geometry"
+#~ msgstr "ज्यामिति"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "पारदर्शी रंग समर्थित नहीं हैं"
+
+#~ msgid "Sailing Ship 3d scan rendered as points"
+#~ msgstr "नौकायन जहाज 3डी स्कैन को बिंदुओं के रूप में प्रतिपादन किया गया"

--- a/po/it.po
+++ b/po/it.po
@@ -1,13 +1,13 @@
-# ITALIAN TRANSLATION.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Italian translation.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
 # ALBANO BATTISTELLA <albanobattistella@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-04 22:15+0200\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-06-07 08:00+0200\n"
 "Last-Translator: Albano Battistella <albanobattistella@gmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -16,292 +16,573 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 data/window.ui:20
-#: data/window.ui:84
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Exhibit"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "Visualizzatore di modelli 3D"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Visualizza l'anteprima dei tuoi modelli 3D"
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:10
+#, fuzzy
+#| msgid ""
+#| "Based on the F3D library that supports many file formats, from digital "
+#| "content to scientific datasets including glTF, USD, STL, STEP, PLY, OBJ, "
+#| "FBX, Alembic and many more. Drag and drop 3d models into the app and "
+#| "export an image of the 3d model. It supports tone mapping, ambient "
+#| "occlusion, anti aliasing and more. You can use an HDRI image or a custom "
+#| "color as a background."
 msgid ""
-"Based on the F3D library that supports many file formats, from digital "
-"content to scientific datasets including glTF, USD, STL, STEP, PLY, OBJ, "
-"FBX, Alembic and many more. Drag and drop 3d models into the app and export "
-"an image of the 3d model. It supports tone mapping, ambient occlusion, anti "
-"aliasing and more. You can use an HDRI image or a custom color as a "
-"background."
+"Based on the F3D library, it supports many file formats, from digital "
+"content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
+"USD, Alembic and many more. You can drag and drop 3d models into the app and "
+"export an image of the rendered model. Change many settings like tone "
+"mapping, ambient occlusion, anti aliasing, material roughness, metallic, "
+"color and opacity to achieve the perfect render. You can use an HDRI image "
+"or a custom color as a background."
 msgstr ""
-"Basato sulla libreria F3D che supporta moltissimi formati di file, dal contenuto "
-"digitale di set di dati scientifici tra cui glTF, USD, STL, STEP, PLY, OBJ, "
-"FBX, Alembic e molti altri. Trascina e rilascia i modelli 3D nell'app ed esporta"
-"un'immagine del modello 3d. Supporta la mappatura dei toni, l'occlusione ambientale, l'anti "
-"aliasing e altro ancora. Puoi utilizzare un'immagine HDRI o un colore personalizzato come "
-"sfondo."
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "Planetary Reducer"
-msgstr "Riduttore planetario"
+"Basato sulla libreria F3D che supporta moltissimi formati di file, dal "
+"contenuto digitale di set di dati scientifici tra cui glTF, USD, STL, STEP, "
+"PLY, OBJ, FBX, Alembic e molti altri. Trascina e rilascia i modelli 3D "
+"nell'app ed esportaun'immagine del modello 3d. Supporta la mappatura dei "
+"toni, l'occlusione ambientale, l'anti aliasing e altro ancora. Puoi "
+"utilizzare un'immagine HDRI o un colore personalizzato come sfondo."
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
-msgid "Nissan Fairlady"
+msgid "3D Benchy"
 msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
-msgid "Retro Computer Setup with a HDRI background"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
+#, fuzzy
+#| msgid "Retro Computer Setup with a HDRI background"
+msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Configurazione del computer retrò con sfondo HDRI"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
-msgid "Benchy with dark theme"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
+msgid "Green Metallic Suzanne"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
+msgid "Cow with an HDRI background and dark theme"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+msgid "Vase 3d scan with HDRI skybox"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
+#, fuzzy
+#| msgid "Benchy with dark theme"
+msgid "Point cloud of a boat with dark theme"
 msgstr "Panchina con tema scuro"
 
-#: src/window.py:293
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Benchy with dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Panchina con tema scuro"
+
+#: src/main.py:129
+msgid "Checkout F3D"
+msgstr ""
+
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Apri file"
 
-#: src/window.py:341
-msgid "Can't open "
+#: src/window.py:847
+#, fuzzy
+#| msgid "Load"
+msgid "Loading {}"
+msgstr "Carica"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Exhibit"
+
+#: src/window.py:942
+#, fuzzy
+#| msgid "Can't open "
+msgid "Can't open"
 msgstr "Impossibile aprire"
 
-#: src/window.py:374
+#: src/window.py:958
 msgid "Save File"
 msgstr "Salva file"
 
-#: src/window.py:375
-msgid "image.png"
-msgstr "immagine.png"
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
 
-#: src/window.py:576
-msgid "Open Skybox File"
-msgstr "Apri il file Skybox"
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
 
-#: data/window.ui:27
-msgid "Reset to Bounds"
-msgstr "Ripristina i limiti"
-
-#: data/window.ui:35
-msgid "Toggle Orthographic"
-msgstr "Attiva/disattiva ortografica"
-
-#: data/window.ui:43
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Menù"
 
-#: data/window.ui:76
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Carica"
 
-#: data/window.ui:80
-msgid "Load any file to view it in 3D"
-msgstr "Carica qualsiasi file per visualizzarlo in 3D"
+#: data/ui/window.ui:110
+msgid "Try Another"
+msgstr ""
 
-#: data/window.ui:145
-msgid "_Open New Window"
-msgstr "_Apri una nuova finestra"
+#: data/ui/window.ui:114
+msgid "Couldn't load the file"
+msgstr ""
 
-#: data/window.ui:151
-msgid "_Load New Model"
-msgstr "_Carica nuovo modello"
+#: data/ui/window.ui:118
+msgid "Error Loading File"
+msgstr ""
 
-#: data/window.ui:157
-msgid "_Save As Image"
-msgstr "_Salva come immagine"
+#: data/ui/window.ui:216
+msgid "Close Sidebar"
+msgstr ""
 
-#: data/window.ui:163
-msgid "_Preferences"
-msgstr "_Preferenze"
-
-#: data/window.ui:167
-msgid "_Keyboard Shortcuts"
-msgstr "_Scorciatoie da tastiera"
-
-#: data/window.ui:171
-msgid "_About Exhibit"
-msgstr "_Informazioni su Exhibit"
-
-#: data/preferences.ui:12 data/preferences.ui:17
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Rendering"
 
-#: data/preferences.ui:22
+#: data/ui/window.ui:267
+#, fuzzy
+#| msgid "Render"
+msgid "Rendering"
+msgstr "Rendering"
+
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "Traslucenza"
 
-#: data/preferences.ui:29
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "Mappatura dei toni"
 
-#: data/preferences.ui:30
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "Mappa i colori correttamente sui colori del monitor"
 
-#: data/preferences.ui:37
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "Occlusione ambientale"
 
-#: data/preferences.ui:38
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "Fornisce ombre approssimative"
 
-#: data/preferences.ui:45
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "Anti Aliasing"
 
-#: data/preferences.ui:52
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "Luce con HDRI"
 
-#: data/preferences.ui:53
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr "Illumina la scena utilizzando l'HDRI caricato o quello predefinito"
 
-#: data/preferences.ui:68
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "Intensità luminosa"
 
-#: data/preferences.ui:77
-msgid "Edges"
-msgstr "Bordi"
+#: data/ui/window.ui:327
+#, fuzzy
+#| msgid "3D Model Viewer"
+msgid "Model Rendering"
+msgstr "Visualizzatore di modelli 3D"
 
-#: data/preferences.ui:82
-msgid "Show Edges"
+#: data/ui/window.ui:332
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Show All Edges"
 msgstr "Mostra bordi"
 
-#: data/preferences.ui:89
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Larghezza dei bordi"
 
-#: data/preferences.ui:109
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Show Point Sprites"
+msgstr "Mostra bordi"
+
+#: data/ui/window.ui:364
+msgid "Point Sprites Type"
+msgstr ""
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Sphere"
+msgstr "Mostra bordi"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+msgid "Sprite Size"
+msgstr ""
+
+#: data/ui/window.ui:390
+msgid "Points Size"
+msgstr ""
+
+#: data/ui/window.ui:413
+msgid "Model"
+msgstr ""
+
+#: data/ui/window.ui:427
+msgid "Material"
+msgstr ""
+
+#: data/ui/window.ui:432
+msgid "Model Metallic"
+msgstr ""
+
+#: data/ui/window.ui:448
+msgid "Model Roughness"
+msgstr ""
+
+#: data/ui/window.ui:465
+msgid "Model Opacity"
+msgstr ""
+
+#: data/ui/window.ui:483
+msgid "Color"
+msgstr ""
+
+#: data/ui/window.ui:489
+msgid "Coloration"
+msgstr ""
+
+#: data/ui/window.ui:493
+msgid "Custom"
+msgstr ""
+
+#: data/ui/window.ui:494
+msgid "Normal"
+msgstr ""
+
+#: data/ui/window.ui:495
+msgid "Magnitude"
+msgstr ""
+
+#: data/ui/window.ui:496
+#, fuzzy
+#| msgid "Up Direction"
+msgid "Direct"
+msgstr "Direzione verso l'alto"
+
+#: data/ui/window.ui:506 data/ui/window.ui:513
+msgid "Model Color"
+msgstr ""
+
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
 msgid "Scene"
 msgstr "Scena"
 
-#: data/preferences.ui:114
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Griglia"
 
-#: data/preferences.ui:119
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Vista griglia"
 
-#: data/preferences.ui:126
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "griglia assoluta"
 
-#: data/preferences.ui:135
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Sfondo"
 
-#: data/preferences.ui:140
-msgid "HDRI as Backgound"
+#: data/ui/window.ui:582
+#, fuzzy
+#| msgid "HDRI as Backgound"
+msgid "HDRI as Background"
 msgstr "HDRI come sfondo"
 
-#: data/preferences.ui:141
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Utilizza l'HDRI caricato o quello predefinito come sfondo"
 
-#: data/preferences.ui:148
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "Immagine HDRI"
 
-#: data/preferences.ui:161
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Sfocatura dello sfondo"
 
-#: data/preferences.ui:168
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Cerchio Sfocato Di Confusione"
 
-#: data/preferences.ui:190
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Usa colore personalizzato"
 
-#: data/preferences.ui:191
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "Lo sfondo HDRI ha la priorità su questo"
 
-#: data/preferences.ui:198
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Colore di sfondo"
 
-#: data/preferences.ui:199
-msgid "Transparent colors not supported"
-msgstr "Colori trasparenti non supportati"
-
-#: data/preferences.ui:219
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Altro"
 
-#: data/preferences.ui:225
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: data/preferences.ui:230
-msgid "Alwayas Point Up"
+#: data/ui/window.ui:680
+#, fuzzy
+#| msgid "Alwayas Point Up"
+msgid "Always Point Up"
 msgstr "Punta sempre verso l'alto"
 
-#: data/preferences.ui:237
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Direzione verso l'alto"
 
-#: data/preferences.ui:242
+#: data/ui/window.ui:688
+msgid "Changing it will reload the file"
+msgstr ""
+
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr ""
 
-#: data/preferences.ui:243
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr ""
 
-#: data/preferences.ui:244
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr ""
 
-#: data/preferences.ui:245
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr ""
 
-#: data/preferences.ui:246
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr ""
 
-#: data/preferences.ui:247
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr ""
 
-#: data/preferences.ui:259
-msgid "Other Settings"
-msgstr "Altre impostazioni"
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Navigazione"
 
-#: data/preferences.ui:264
-msgid "Automatic Up Direction"
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
+#, fuzzy
+#| msgid "Load"
+msgid "Loading"
+msgstr "Carica"
+
+#: data/ui/window.ui:761
+#, fuzzy
+#| msgid "Automatic Up Direction"
+msgid "Automatic Settings"
 msgstr "Direzione automatica verso l'alto"
 
-#: data/preferences.ui:265
-msgid "When loading choose the best up direction"
+#: data/ui/window.ui:762
+#, fuzzy
+#| msgid "When loading choose the best up direction"
+msgid "When loading choose the best presets for the file"
 msgstr "Durante il caricamento scegliere la migliore direzione verso l'alto"
 
-#: data/preferences.ui:272
-msgid "Save Settings"
+#: data/ui/window.ui:775
+msgid "Reload On Change"
+msgstr ""
+
+#: data/ui/window.ui:776
+msgid "Check for file change"
+msgstr ""
+
+#: data/ui/window.ui:826
+msgid "Reveal Sidebar"
+msgstr ""
+
+#: data/ui/window.ui:849
+msgid "Reset to Bounds"
+msgstr "Ripristina i limiti"
+
+#: data/ui/window.ui:911
+msgid "Follow System"
+msgstr ""
+
+#: data/ui/window.ui:916
+msgid "Light Theme"
+msgstr ""
+
+#: data/ui/window.ui:921
+msgid "Dark Theme"
+msgstr ""
+
+#: data/ui/window.ui:926 data/ui/window.ui:990
+#, fuzzy
+#| msgid "_Open New Window"
+msgid "_New Window"
+msgstr "_Apri una nuova finestra"
+
+#: data/ui/window.ui:930
+#, fuzzy
+#| msgid "_Load New Model"
+msgid "_Load New File"
+msgstr "_Carica nuovo modello"
+
+#: data/ui/window.ui:938
+msgid "_Export Image"
+msgstr ""
+
+#: data/ui/window.ui:942
+msgid "_Open In External App"
+msgstr ""
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
+msgid "_Help"
+msgstr ""
+
+#: data/ui/window.ui:952 data/ui/window.ui:1000
+msgid "_Keyboard Shortcuts"
+msgstr "_Scorciatoie da tastiera"
+
+#: data/ui/window.ui:956 data/ui/window.ui:1004
+msgid "_About Exhibit"
+msgstr "_Informazioni su Exhibit"
+
+#: data/ui/window.ui:966
+#, fuzzy
+#| msgid "Save Settings"
+msgid "Save Current Settings"
 msgstr "Salva le impostazioni"
 
-#: data/preferences.ui:282
-msgid "Restore Settings"
-msgstr "Ripristino delle impostazioni"
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Attiva/disattiva ortografica"
 
-#: data/preferences.ui:298
-msgid "Reset Settings"
-msgstr "Ripristina impostazioni"
+#: data/ui/window.ui:978
+#, fuzzy
+#| msgid "Open File"
+msgid "Open HDRI Folder"
+msgstr "Apri file"
 
-#: data/preferences.ui:307
-msgid ""
-"Preferences are per window basis, if you save them next time you will open "
-"the app it will start with these preferences"
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
 msgstr ""
-"Le preferenze sono per finestra, se le salvi la prossima volta che le aprirai "
-"l'app partirà con queste preferenze"
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open File"
+msgid "Open HDRI"
+msgstr "Apri file"
+
+#, fuzzy
+#~| msgid "Benchy with dark theme"
+#~ msgid "Nissan Fairlady with dark theme"
+#~ msgstr "Panchina con tema scuro"
+
+#, fuzzy
+#~| msgid "Load"
+#~ msgid "Load type"
+#~ msgstr "Carica"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "Colori trasparenti non supportati"
+
+#~ msgid "Planetary Reducer"
+#~ msgstr "Riduttore planetario"
+
+#~ msgid "image.png"
+#~ msgstr "immagine.png"
+
+#~ msgid "Open Skybox File"
+#~ msgstr "Apri il file Skybox"
+
+#~ msgid "Load any file to view it in 3D"
+#~ msgstr "Carica qualsiasi file per visualizzarlo in 3D"
+
+#~ msgid "_Save As Image"
+#~ msgstr "_Salva come immagine"
+
+#~ msgid "_Preferences"
+#~ msgstr "_Preferenze"
+
+#~ msgid "Edges"
+#~ msgstr "Bordi"
+
+#~ msgid "Other Settings"
+#~ msgstr "Altre impostazioni"
+
+#~ msgid "Restore Settings"
+#~ msgstr "Ripristino delle impostazioni"
+
+#~ msgid "Reset Settings"
+#~ msgstr "Ripristina impostazioni"
+
+#~ msgid ""
+#~ "Preferences are per window basis, if you save them next time you will "
+#~ "open the app it will start with these preferences"
+#~ msgstr ""
+#~ "Le preferenze sono per finestra, se le salvi la prossima volta che le "
+#~ "aprirai l'app partirà con queste preferenze"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Norvegian Bokmål translation.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
+# Sunniva Løvstad <turtle@turle.garden>, 2024.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-04 15:16+0200\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-10-04 23:47+0200\n"
 "Last-Translator: Sunniva Løvstad <turtle@turtle.garden>\n"
 "Language-Team: \n"
@@ -18,21 +18,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:848
-#: data/ui/window.ui:11 data/ui/window.ui:77 data/ui/window.ui:155
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Exhibit"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "3D-modellvisere"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+#, fuzzy
+#| msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;gjengivelse;3d-modell;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:73
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Forhåndsvis 3D-modellene dine"
 
@@ -55,372 +58,468 @@ msgstr ""
 "for å oppnå den perfekte gjengivelsen. Du kan bruke et HDRI-bilde eller en "
 "tilpasset farge som bakgrunn."
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "3D Bechy"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#, fuzzy
+#| msgid "3D Bechy"
+msgid "3D Benchy"
 msgstr "Bechy i 3D"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
 msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Et retro-datasett med HDRI-skybox"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
 msgid "Green Metallic Suzanne"
 msgstr "Grøn metallisk Suzanne"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
 msgid "Cow with an HDRI background and dark theme"
 msgstr "Ku med HDRI-skybox og mørk drakt"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:58
-msgid "Nissan Fairlady with dark theme"
-msgstr "Nissan Fairlady med mørk drakt"
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:62
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
 msgid "Vase 3d scan with HDRI skybox"
 msgstr "En 3D-skanning av en vase med HDRI-skybox"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
 msgid "Point cloud of a boat with dark theme"
 msgstr "Punktsky av en båt med mørk drakt"
 
-#: src/main.py:140
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Point cloud of a boat with dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Punktsky av en båt med mørk drakt"
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr "Sjekk ut F3D"
 
-#: src/window.py:713
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Åpne fil"
 
-#: src/window.py:853
+#: src/window.py:847
+#, fuzzy
+#| msgid "Loading"
+msgid "Loading {}"
+msgstr "Laster inn"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Exhibit"
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr "Kan ikke åpne"
 
-#: src/window.py:869
+#: src/window.py:958
 msgid "Save File"
 msgstr "Lagre fil"
 
-#: data/ui/window.ui:49 data/ui/window.ui:178 data/ui/window.ui:185
-#: data/ui/window.ui:711
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
+
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Meny"
 
-#: data/ui/window.ui:69
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Last inn fil…"
 
-#: data/ui/window.ui:95
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr "Prøv en annen"
 
-#: data/ui/window.ui:99
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr "Kunne ikke laste inn filen"
 
-#: data/ui/window.ui:103
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "Feil ved innlasting av filen"
 
-#: data/ui/window.ui:161 data/ui/window.ui:719
-msgid "Open With External App"
-msgstr "Åpne med ekstern app"
-
-#: data/ui/window.ui:171
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "Steng sidefelt"
 
-#: data/ui/window.ui:208
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Gjengi"
 
-#: data/ui/window.ui:222
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "Gjengivelse"
 
-#: data/ui/window.ui:227
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "Gjennomsiktighet"
 
-#: data/ui/window.ui:234
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "Tonekartlegging"
 
-#: data/ui/window.ui:235
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "Kartlegg farger riktig til fargene på skjermen"
 
-#: data/ui/window.ui:242
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "Omgivelsesokklusjon"
 
-#: data/ui/window.ui:243
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "Gjengir omtrentlige skygger"
 
-#: data/ui/window.ui:250
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "Antialiasing"
 
-#: data/ui/window.ui:257
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "Belys med HDRI"
 
-#: data/ui/window.ui:258
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr ""
 "Belys senen med bruk av enten det innlastede HDRI-bildet eller standarden"
 
-#: data/ui/window.ui:273
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "Belysningsintensitet"
 
-#: data/ui/window.ui:282
+#: data/ui/window.ui:327
 msgid "Model Rendering"
 msgstr "Modellgjengivelse"
 
-#: data/ui/window.ui:287
+#: data/ui/window.ui:332
 msgid "Show All Edges"
 msgstr "Vis alle kanter"
 
-#: data/ui/window.ui:294
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Kantbredde"
 
-#: data/ui/window.ui:316
-msgid "Show Spheres"
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Show Point Sprites"
 msgstr "Kantsfærer"
 
-#: data/ui/window.ui:323
+#: data/ui/window.ui:364
+#, fuzzy
+#| msgid "Points Size"
+msgid "Point Sprites Type"
+msgstr "Punktstørrelse"
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Sphere"
+msgstr "Kantsfærer"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+#, fuzzy
+#| msgid "Points Size"
+msgid "Sprite Size"
+msgstr "Punktstørrelse"
+
+#: data/ui/window.ui:390
 msgid "Points Size"
 msgstr "Punktstørrelse"
 
-#: data/ui/window.ui:347 data/ui/window.ui:361
+#: data/ui/window.ui:413
 msgid "Model"
 msgstr "Modell"
 
-#: data/ui/window.ui:367
-msgid "Load type"
-msgstr "Innlastingstype"
-
-#: data/ui/window.ui:371
-msgid "Geometry"
-msgstr "Geometri"
-
-#: data/ui/window.ui:372 data/ui/window.ui:488
-msgid "Scene"
-msgstr "Sene"
-
-#: data/ui/window.ui:385
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "Materiell"
 
-#: data/ui/window.ui:390
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "Modellmetalliskhet"
 
-#: data/ui/window.ui:406
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "Modellujevnhet"
 
-#: data/ui/window.ui:423
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "Modellgjennomsiktighet"
 
-#: data/ui/window.ui:441
+#: data/ui/window.ui:483
 msgid "Color"
 msgstr "Farge"
 
-#: data/ui/window.ui:447
+#: data/ui/window.ui:489
 msgid "Coloration"
 msgstr "Farging"
 
-#: data/ui/window.ui:451
+#: data/ui/window.ui:493
 msgid "Custom"
 msgstr "Tilpasset"
 
-#: data/ui/window.ui:452
+#: data/ui/window.ui:494
 msgid "Normal"
 msgstr "Normal"
 
-#: data/ui/window.ui:453
+#: data/ui/window.ui:495
 msgid "Magnitude"
 msgstr "Størrelse"
 
-#: data/ui/window.ui:454
+#: data/ui/window.ui:496
 msgid "Direct"
 msgstr "Direkt"
 
-#: data/ui/window.ui:464
+#: data/ui/window.ui:506 data/ui/window.ui:513
 msgid "Model Color"
 msgstr "Modellfarge"
 
-#: data/ui/window.ui:502
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "Sene"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Rutenett"
 
-#: data/ui/window.ui:507
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Vis rutenett"
 
-#: data/ui/window.ui:514
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Absolutt rutenett"
 
-#: data/ui/window.ui:523
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: data/ui/window.ui:528
+#: data/ui/window.ui:582
 msgid "HDRI as Background"
 msgstr "HDRI som bakgrunn"
 
-#: data/ui/window.ui:529
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Bruk det innlastede HDRI-bildet eller standarden som bakgrunn"
 
-#: data/ui/window.ui:536
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "HDRI-bilde"
 
-#: data/ui/window.ui:543
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Gjør bakgrunnen uskarp"
 
-#: data/ui/window.ui:550
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Bakgrunnsuskarphet"
 
-#: data/ui/window.ui:572
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Bruk tilpasset farge"
 
-#: data/ui/window.ui:573
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "HDRI-bakgrunnsinnstillingen overstyrer dette"
 
-#: data/ui/window.ui:580
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Bakgrunnsfarge"
 
-#: data/ui/window.ui:581
-msgid "Transparent colors not supported"
-msgstr "Gjennomsiktige farger støttes ikke"
-
-#: data/ui/window.ui:605
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Mer"
 
-#: data/ui/window.ui:619
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Navigering"
 
-#: data/ui/window.ui:624
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr "Pek alltid oppover"
 
-#: data/ui/window.ui:631
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Opp-retning"
 
-#: data/ui/window.ui:632
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "Å endre dette laster inn filen på nytt"
 
-#: data/ui/window.ui:636
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr "- X"
 
-#: data/ui/window.ui:637
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr "+ X"
 
-#: data/ui/window.ui:638
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr "- Y"
 
-#: data/ui/window.ui:639
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr "+ Y"
 
-#: data/ui/window.ui:640
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr "- Z"
 
-#: data/ui/window.ui:641
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr "+ Z"
 
-#: data/ui/window.ui:653
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Navigering"
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
 msgid "Loading"
 msgstr "Laster inn"
 
-#: data/ui/window.ui:658
+#: data/ui/window.ui:761
 msgid "Automatic Settings"
 msgstr "Automatiske innstillinger"
 
-#: data/ui/window.ui:659
+#: data/ui/window.ui:762
 msgid "When loading choose the best presets for the file"
 msgstr "Ved innlasting skal Exhibit velge de beste standardene for filen"
 
-#: data/ui/window.ui:672
+#: data/ui/window.ui:775
 msgid "Reload On Change"
 msgstr "Last inn på nytt ved endring"
 
-#: data/ui/window.ui:673
+#: data/ui/window.ui:776
 msgid "Check for file change"
 msgstr "Sjekk for filendring"
 
-#: data/ui/window.ui:702
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "Vis sidefelt"
 
-#: data/ui/window.ui:728
-msgid "Toggle Orthographic"
-msgstr "Slå på/av ortografiskmodus"
-
-#: data/ui/window.ui:736
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr "Tilbakestille til grensene"
 
-#: data/ui/window.ui:798
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "Følg systemet"
 
-#: data/ui/window.ui:803
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "Lys drakt"
 
-#: data/ui/window.ui:808
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "Mørk drakt"
 
-#: data/ui/window.ui:813 data/ui/window.ui:863
+#: data/ui/window.ui:926 data/ui/window.ui:990
 msgid "_New Window"
 msgstr "_Nytt vindu"
 
-#: data/ui/window.ui:819
+#: data/ui/window.ui:930
 msgid "_Load New File"
 msgstr "_Last inn ny fil"
 
-#: data/ui/window.ui:825
+#: data/ui/window.ui:938
 msgid "_Export Image"
 msgstr "_Eksporter bilde"
 
-#: data/ui/window.ui:831 data/ui/window.ui:869
+#: data/ui/window.ui:942
+#, fuzzy
+#| msgid "Open With External App"
+msgid "_Open In External App"
+msgstr "Åpne med ekstern app"
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
 msgid "_Help"
 msgstr "_Hjelp"
 
-#: data/ui/window.ui:835 data/ui/window.ui:873
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "_Tastatursnarveier"
 
-#: data/ui/window.ui:839 data/ui/window.ui:877
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr "_Om Exhibit"
 
-#: data/ui/window.ui:849
+#: data/ui/window.ui:966
 msgid "Save Current Settings"
 msgstr "Lagre nåværende innstillinger"
 
-#: data/ui/window.ui:855
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Slå på/av ortografiskmodus"
+
+#: data/ui/window.ui:978
 msgid "Open HDRI Folder"
 msgstr "Åpne HDRI-mappen"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open HDRI Folder"
+msgid "Open HDRI"
+msgstr "Åpne HDRI-mappen"
+
+#~ msgid "Nissan Fairlady with dark theme"
+#~ msgstr "Nissan Fairlady med mørk drakt"
+
+#~ msgid "Load type"
+#~ msgstr "Innlastingstype"
+
+#~ msgid "Geometry"
+#~ msgstr "Geometri"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "Gjennomsiktige farger støttes ikke"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,13 +1,13 @@
 # Brazilian Portuguese translation for Exhibit
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
 # Tiago Lucas Flach <tiagolucas9830@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-15 16:47+0200\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-06-23 20:19-0300\n"
 "Last-Translator: Tiago Lucas Flach <tiagolucas9830@gmail.com>\n"
 "Language-Team: \n"
@@ -17,32 +17,44 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:577
-#: data/ui/window.ui:11 data/ui/window.ui:84 data/ui/window.ui:159
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Exhibit"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "Visualizador de Modelos 3D"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+#, fuzzy
+#| msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;renderização,modelo-3d;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:80
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Visualize seus modelos 3D"
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:10
+#, fuzzy
+#| msgid ""
+#| "Based on the F3D library that supports many file formats, from digital "
+#| "content to scientific datasets including glTF, USD, STL, STEP, PLY, OBJ, "
+#| "FBX, Alembic and many more. Drag and drop 3d models into the app and "
+#| "export an image of the 3d model. It supports tone mapping, ambient "
+#| "occlusion, anti aliasing and more. You can use an HDRI image or a custom "
+#| "color as a background."
 msgid ""
-"Based on the F3D library that supports many file formats, from digital "
-"content to scientific datasets including glTF, USD, STL, STEP, PLY, OBJ, "
-"FBX, Alembic and many more. Drag and drop 3d models into the app and export "
-"an image of the 3d model. It supports tone mapping, ambient occlusion, anti "
-"aliasing and more. You can use an HDRI image or a custom color as a "
-"background."
+"Based on the F3D library, it supports many file formats, from digital "
+"content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
+"USD, Alembic and many more. You can drag and drop 3d models into the app and "
+"export an image of the rendered model. Change many settings like tone "
+"mapping, ambient occlusion, anti aliasing, material roughness, metallic, "
+"color and opacity to achieve the perfect render. You can use an HDRI image "
+"or a custom color as a background."
 msgstr ""
 "Baseado na biblioteca F3D que suporta muitos formatos de arquivo, desde "
 "conteúdo digital até conjuntos de dados científicos, incluindo glTF, USD, "
@@ -51,343 +63,536 @@ msgstr ""
 "oclusão de ambiente, anti-aliasing e muito mais. Você pode usar uma imagem "
 "HDRI ou uma cor personalizada como plano de fundo."
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "Planetary Reducer"
-msgstr "Redutor Planetário"
-
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
-msgid "Nissan Fairlady"
-msgstr "Nissan Fairlady"
+msgid "3D Benchy"
+msgstr ""
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
-msgid "Retro Computer Setup with a HDRI background"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
+#, fuzzy
+#| msgid "Retro Computer Setup with a HDRI background"
+msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Configuração de Computador Retrô com fundo HDRI"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
-msgid "Benchy with dark theme"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
+msgid "Green Metallic Suzanne"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
+msgid "Cow with an HDRI background and dark theme"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+msgid "Vase 3d scan with HDRI skybox"
+msgstr ""
+
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
+#, fuzzy
+#| msgid "Benchy with dark theme"
+msgid "Point cloud of a boat with dark theme"
 msgstr "Banco com tema escuro"
 
-#: src/main.py:104
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Benchy with dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Banco com tema escuro"
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr "Checkout F3DCheckout F3D"
 
-#: src/window.py:478
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Abrir arquivo"
 
-#: src/window.py:582
+#: src/window.py:847
+#, fuzzy
+#| msgid "Load"
+msgid "Loading {}"
+msgstr "Carregar"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Exhibit"
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr "Não foi possível abrir"
 
-#: src/window.py:607
+#: src/window.py:958
 msgid "Save File"
 msgstr "Salvar Arquivo"
 
-#: src/window.py:801
-msgid "Open Skybox File"
-msgstr "Abrir Arquivo Skybox"
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
 
-#: data/ui/window.ui:46 data/ui/window.ui:176 data/ui/window.ui:715
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Menu"
 
-#: data/ui/window.ui:76
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Carregar"
 
-#: data/ui/window.ui:100
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr "Tentar Outro"
 
-#: data/ui/window.ui:104
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr "Não foi possível carregar o arquivo"
 
-#: data/ui/window.ui:108
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "Erro ao Carregar Arquivo"
 
-#: data/ui/window.ui:167
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "Fechar Barra Lateral"
 
-#: data/ui/window.ui:198 data/ui/window.ui:212
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Renderizar"
 
-#: data/ui/window.ui:217
-msgid "Translucency"
-msgstr "Translucidez"
-
-#: data/ui/window.ui:224
-msgid "Tone Mapping"
-msgstr "Mapeamento de Tons"
-
-#: data/ui/window.ui:225
-msgid "Map colors properly to the monitor colors"
-msgstr "Mapeie as cores corretamente para as cores do monitor"
-
-#: data/ui/window.ui:232
-msgid "Ambient Occlusion"
-msgstr "Oclusão de Ambiente"
-
-#: data/ui/window.ui:233
-msgid "Provides approximate shadows"
-msgstr "Fornece Sombras Aproximadas"
-
-#: data/ui/window.ui:240
-msgid "Anti Aliasing"
-msgstr "Anti-aliasing"
-
-#: data/ui/window.ui:247
-msgid "Light with HDRI"
-msgstr "Iluminação com HDRI"
-
-#: data/ui/window.ui:248
-msgid "Light the scene using a the loaded HDRI or the default"
-msgstr "Ilumine a cena usando o HDRI carregado ou o padrão"
-
-#: data/ui/window.ui:263
-msgid "Light Intensity"
-msgstr "Intensidade da Luz"
-
-#: data/ui/window.ui:278 data/ui/window.ui:292
-msgid "Model"
-msgstr "Modelo"
-
-#: data/ui/window.ui:298
-#, fuzzy
-msgid "Load type"
-msgstr "Carregar"
-
-#: data/ui/window.ui:302
-msgid "Geometry"
-msgstr "Geometria"
-
-#: data/ui/window.ui:303 data/ui/window.ui:459
-msgid "Scene"
-msgstr "Cena"
-
-#: data/ui/window.ui:315
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "Renderizando"
 
-#: data/ui/window.ui:322
-msgid "Show Edges"
+#: data/ui/window.ui:272
+msgid "Translucency"
+msgstr "Translucidez"
+
+#: data/ui/window.ui:279
+msgid "Tone Mapping"
+msgstr "Mapeamento de Tons"
+
+#: data/ui/window.ui:280
+msgid "Map colors properly to the monitor colors"
+msgstr "Mapeie as cores corretamente para as cores do monitor"
+
+#: data/ui/window.ui:287
+msgid "Ambient Occlusion"
+msgstr "Oclusão de Ambiente"
+
+#: data/ui/window.ui:288
+msgid "Provides approximate shadows"
+msgstr "Fornece Sombras Aproximadas"
+
+#: data/ui/window.ui:295
+msgid "Anti Aliasing"
+msgstr "Anti-aliasing"
+
+#: data/ui/window.ui:302
+msgid "Light with HDRI"
+msgstr "Iluminação com HDRI"
+
+#: data/ui/window.ui:303
+msgid "Light the scene using a the loaded HDRI or the default"
+msgstr "Ilumine a cena usando o HDRI carregado ou o padrão"
+
+#: data/ui/window.ui:318
+msgid "Light Intensity"
+msgstr "Intensidade da Luz"
+
+#: data/ui/window.ui:327
+#, fuzzy
+#| msgid "Rendering"
+msgid "Model Rendering"
+msgstr "Renderizando"
+
+#: data/ui/window.ui:332
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Show All Edges"
 msgstr "Mostrar Arestas"
 
-#: data/ui/window.ui:328
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Largura das Arestas"
 
-#: data/ui/window.ui:353
-msgid "Show Points"
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Points"
+msgid "Show Point Sprites"
 msgstr "Mostrar Pontos"
 
-#: data/ui/window.ui:359
-msgid "Points Radius"
+#: data/ui/window.ui:364
+#, fuzzy
+#| msgid "Points Radius"
+msgid "Point Sprites Type"
 msgstr "Raio dos Pontos"
 
-#: data/ui/window.ui:378
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Edges"
+msgid "Sphere"
+msgstr "Mostrar Arestas"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+#, fuzzy
+#| msgid "Points Radius"
+msgid "Sprite Size"
+msgstr "Raio dos Pontos"
+
+#: data/ui/window.ui:390
+#, fuzzy
+#| msgid "Points Radius"
+msgid "Points Size"
+msgstr "Raio dos Pontos"
+
+#: data/ui/window.ui:413
+msgid "Model"
+msgstr "Modelo"
+
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "Material"
 
-#: data/ui/window.ui:383
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "Modelo Metálico"
 
-#: data/ui/window.ui:400
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "Rugosidade do Modelo"
 
-#: data/ui/window.ui:417
-msgid "Model Color"
-msgstr "Cor do Modelo"
-
-#: data/ui/window.ui:433
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "Opacidade do Modelo"
 
-#: data/ui/window.ui:473
+#: data/ui/window.ui:483
+#, fuzzy
+#| msgid "Model Color"
+msgid "Color"
+msgstr "Cor do Modelo"
+
+#: data/ui/window.ui:489
+msgid "Coloration"
+msgstr ""
+
+#: data/ui/window.ui:493
+msgid "Custom"
+msgstr ""
+
+#: data/ui/window.ui:494
+msgid "Normal"
+msgstr ""
+
+#: data/ui/window.ui:495
+msgid "Magnitude"
+msgstr ""
+
+#: data/ui/window.ui:496
+#, fuzzy
+#| msgid "Up Direction"
+msgid "Direct"
+msgstr "Direção Para Cima"
+
+#: data/ui/window.ui:506 data/ui/window.ui:513
+msgid "Model Color"
+msgstr "Cor do Modelo"
+
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "Cena"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Grade"
 
-#: data/ui/window.ui:478
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Ver Grade"
 
-#: data/ui/window.ui:485
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Grade Absoluta"
 
-#: data/ui/window.ui:494
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Plano de fundo"
 
-#: data/ui/window.ui:499
-msgid "HDRI as Backgound"
+#: data/ui/window.ui:582
+#, fuzzy
+#| msgid "HDRI as Backgound"
+msgid "HDRI as Background"
 msgstr "HDRI como plano de fundo"
 
-#: data/ui/window.ui:500
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Use o HDRI carregado ou o padrão como plano de fundo"
 
-#: data/ui/window.ui:507
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "Imagem HDRI"
 
-#: data/ui/window.ui:514
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Desfocar Fundo"
 
-#: data/ui/window.ui:521
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Desfocar Círculo de Confusão"
 
-#: data/ui/window.ui:543
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Usar Cor Personalizada"
 
-#: data/ui/window.ui:544
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "O plano de fundo HDRI tem prioridade sobre isso"
 
-#: data/ui/window.ui:551
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Cor de Fundo"
 
-#: data/ui/window.ui:552
-msgid "Transparent colors not supported"
-msgstr "Cores transparentes não suportadas"
-
-#: data/ui/window.ui:576
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Mais"
 
-#: data/ui/window.ui:590
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Navegação"
 
-#: data/ui/window.ui:595
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr "Sempre Apontar Para Cima"
 
-#: data/ui/window.ui:602
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Direção Para Cima"
 
-#: data/ui/window.ui:603
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "Alterá-lo irá recarregar o arquivo"
 
-#: data/ui/window.ui:607
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr "- X"
 
-#: data/ui/window.ui:608
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr "- X"
 
-#: data/ui/window.ui:609
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr "- Y"
 
-#: data/ui/window.ui:610
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr "+ Y"
 
-#: data/ui/window.ui:611
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr "- Z"
 
-#: data/ui/window.ui:612
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr "+ Z"
 
-#: data/ui/window.ui:624
-msgid "Other Settings"
-msgstr "Outros Ajustes"
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Navegação"
 
-#: data/ui/window.ui:629
-msgid "Automatic Up Direction"
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
+#, fuzzy
+#| msgid "Load"
+msgid "Loading"
+msgstr "Carregar"
+
+#: data/ui/window.ui:761
+#, fuzzy
+#| msgid "Automatic Up Direction"
+msgid "Automatic Settings"
 msgstr "Direção Automática Para Cima"
 
-#: data/ui/window.ui:630
-msgid "When loading choose the best up direction"
+#: data/ui/window.ui:762
+#, fuzzy
+#| msgid "When loading choose the best up direction"
+msgid "When loading choose the best presets for the file"
 msgstr "Ao carregar, escolha a melhor direção para cima"
 
-#: data/ui/window.ui:637
-msgid "Save Settings"
-msgstr "Salvar Configurações"
-
-#: data/ui/window.ui:647
-msgid "Restore Settings"
-msgstr "Restaurar Configurações"
-
-#: data/ui/window.ui:663
-msgid "Reset Settings"
-msgstr "Redefinir as Configurações"
-
-#: data/ui/window.ui:672
-msgid ""
-"Preferences are per window basis, if you save them next time you will open "
-"the app it will start with these preferences"
+#: data/ui/window.ui:775
+msgid "Reload On Change"
 msgstr ""
-"As preferências são por janela. Se você salvá-las na próxima vez que abrir o "
-"aplicativo, ele começará com essas preferências"
 
-#: data/ui/window.ui:708
+#: data/ui/window.ui:776
+msgid "Check for file change"
+msgstr ""
+
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "Revelar Barra Lateral"
 
-#: data/ui/window.ui:724
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr "Redefinir para Limites"
 
-#: data/ui/window.ui:732
-msgid "Toggle Orthographic"
-msgstr "Alternar Ortográfica"
-
-#: data/ui/window.ui:818
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "Seguir o Sistema"
 
-#: data/ui/window.ui:823
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "Tema Claro"
 
-#: data/ui/window.ui:828
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "Tema Escuro"
 
-#: data/ui/window.ui:833 data/ui/window.ui:863
-msgid "_Open New Window"
+#: data/ui/window.ui:926 data/ui/window.ui:990
+#, fuzzy
+#| msgid "_Open New Window"
+msgid "_New Window"
 msgstr "_Abrir Nova Janela"
 
-#: data/ui/window.ui:839
-msgid "_Load"
-msgstr "_Carregar"
+#: data/ui/window.ui:930
+#, fuzzy
+#| msgid "_Load New Model"
+msgid "_Load New File"
+msgstr "_Carregar Novo Modelo"
 
-#: data/ui/window.ui:845
-msgid "_Save As Image"
-msgstr "_Salvar Como Imagem"
+#: data/ui/window.ui:938
+msgid "_Export Image"
+msgstr ""
 
-#: data/ui/window.ui:851 data/ui/window.ui:869
+#: data/ui/window.ui:942
+msgid "_Open In External App"
+msgstr ""
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
+msgid "_Help"
+msgstr ""
+
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "_Atalhos do Teclado"
 
-#: data/ui/window.ui:855 data/ui/window.ui:873
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr "_Sobre o Exhibit"
+
+#: data/ui/window.ui:966
+#, fuzzy
+#| msgid "Save Settings"
+msgid "Save Current Settings"
+msgstr "Salvar Configurações"
+
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Alternar Ortográfica"
+
+#: data/ui/window.ui:978
+#, fuzzy
+#| msgid "Open File"
+msgid "Open HDRI Folder"
+msgstr "Abrir arquivo"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open File"
+msgid "Open HDRI"
+msgstr "Abrir arquivo"
+
+#, fuzzy
+#~| msgid "Benchy with dark theme"
+#~ msgid "Nissan Fairlady with dark theme"
+#~ msgstr "Banco com tema escuro"
+
+#, fuzzy
+#~ msgid "Load type"
+#~ msgstr "Carregar"
+
+#~ msgid "Geometry"
+#~ msgstr "Geometria"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "Cores transparentes não suportadas"
+
+#~ msgid "Planetary Reducer"
+#~ msgstr "Redutor Planetário"
+
+#~ msgid "Nissan Fairlady"
+#~ msgstr "Nissan Fairlady"
+
+#~ msgid "Open Skybox File"
+#~ msgstr "Abrir Arquivo Skybox"
+
+#~ msgid "Other Settings"
+#~ msgstr "Outros Ajustes"
+
+#~ msgid "Restore Settings"
+#~ msgstr "Restaurar Configurações"
+
+#~ msgid "Reset Settings"
+#~ msgstr "Redefinir as Configurações"
+
+#~ msgid ""
+#~ "Preferences are per window basis, if you save them next time you will "
+#~ "open the app it will start with these preferences"
+#~ msgstr ""
+#~ "As preferências são por janela. Se você salvá-las na próxima vez que "
+#~ "abrir o aplicativo, ele começará com essas preferências"
+
+#~ msgid "_Load"
+#~ msgstr "_Carregar"
+
+#~ msgid "_Save As Image"
+#~ msgstr "_Salvar Como Imagem"
 
 #~ msgid "image"
 #~ msgstr "imagem"
 
 #~ msgid "Load any file to view it in 3D"
 #~ msgstr "Carregue qualquer arquivo para visualizá-lo em 3D"
-
-#~ msgid "_Load New Model"
-#~ msgstr "_Carregar Novo Modelo"
 
 #~ msgid "_Preferences"
 #~ msgstr "_Preferências"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,14 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Russian translation.
+# Copyright (C) 2026, Nokse22
+# This file is distributed under the same license as the Exhibit package.
+# Egor <petruhin-enot@yandex.ru>, 2024.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: Exhibit\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-29 23:06+0200\n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-08-10 13:03+0400\n"
 "Last-Translator: Egor <petruhin-enot@yandex.ru>\n"
 "Language-Team: \n"
@@ -18,27 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:843
-#: data/ui/window.ui:11 data/ui/window.ui:77 data/ui/window.ui:156
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Exhibit"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "Просмотрщик 3D моделей"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+#, fuzzy
+#| msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:73
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Предварительный просмотр ваших 3D-моделей"
 
 #: data/io.github.nokse22.Exhibit.metainfo.xml.in:10
+#, fuzzy
+#| msgid ""
+#| "Based on the F3D library that supports many file formats, from digital "
+#| "content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
+#| "USD, Alembic and many more. You can drag and drop 3d models into the app "
+#| "and export an image of the rendered model. Change many settings like tone "
+#| "mapping, ambient occlusion, anti aliasing, material roughness, metallic, "
+#| "color and opacity to achieve the perfect render. You can use an HDRI "
+#| "image or a custom color as a background."
 msgid ""
-"Based on the F3D library that supports many file formats, from digital "
+"Based on the F3D library, it supports many file formats, from digital "
 "content to scientific datasets including glTF, STL, STEP, PLY, OBJ, FBX, "
 "USD, Alembic and many more. You can drag and drop 3d models into the app and "
 "export an image of the rendered model. Change many settings like tone "
@@ -55,371 +66,473 @@ msgstr ""
 "добиться идеального рендера. В качестве фона можно использовать HDRI-"
 "изображение или пользовательский цвет."
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "Bechy"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#, fuzzy
+#| msgid "Bechy"
+msgid "3D Benchy"
 msgstr "Bechy"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
-msgid "Retro Computer Setup with a HDRI background"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
+#, fuzzy
+#| msgid "Retro Computer Setup with a HDRI background"
+msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Ретро компьютер с HDRI фоном"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
 msgid "Green Metallic Suzanne"
 msgstr "Зеленая металлическая Сюзанна"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
-msgid "Cow with a HDRI background in dark theme"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
+#, fuzzy
+#| msgid "Cow with a HDRI background in dark theme"
+msgid "Cow with an HDRI background and dark theme"
 msgstr "Корова с HDRI фоном и темная тема"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:58
-msgid "Nissan Fairlady in dark theme"
-msgstr "Nissan Fairlady и темная тема"
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:62
-msgid "Vase 3d scan with HDRI"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+#, fuzzy
+#| msgid "Vase 3d scan with HDRI"
+msgid "Vase 3d scan with HDRI skybox"
 msgstr "3D-скан вазы с HDRI"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
-msgid "Sailing Ship 3d scan rendered as points"
-msgstr "3D-скан плавающего корабля в виде точек"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
+msgid "Point cloud of a boat with dark theme"
+msgstr ""
 
-#: src/main.py:127
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Nissan Fairlady in dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Nissan Fairlady и темная тема"
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr "Проверить F3D"
 
-#: src/window.py:711
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Открыть файл"
 
-#: src/window.py:848
+#: src/window.py:847
+#, fuzzy
+#| msgid "Loading"
+msgid "Loading {}"
+msgstr "Загрузка"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Exhibit"
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr "Невозможно открыть"
 
-#: src/window.py:864
+#: src/window.py:958
 msgid "Save File"
 msgstr "Сохранить файл"
 
-#: data/ui/window.ui:49 data/ui/window.ui:179 data/ui/window.ui:186
-#: data/ui/window.ui:714
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
+
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Меню"
 
-#: data/ui/window.ui:69
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Открыть"
 
-#: data/ui/window.ui:96
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr "Попробовать другой"
 
-#: data/ui/window.ui:100
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr "Невозможно открыть файл"
 
-#: data/ui/window.ui:104
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "Ошибка открытия файла"
 
-#: data/ui/window.ui:162 data/ui/window.ui:722
-msgid "Open With External App"
-msgstr "Открыть через стороннее приложение"
-
-#: data/ui/window.ui:172
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "Закрыть боковую панель"
 
-#: data/ui/window.ui:209
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Рендер"
 
-#: data/ui/window.ui:223
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "Рендеринг"
 
-#: data/ui/window.ui:228
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "Полупрозрачность"
 
-#: data/ui/window.ui:235
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "Тональное отображение"
 
-#: data/ui/window.ui:236
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "Правильное отображение цветов на мониторе"
 
-#: data/ui/window.ui:243
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "Окружающее затенение"
 
-#: data/ui/window.ui:244
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "Предоставляет приблизительные тени"
 
-#: data/ui/window.ui:251
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "Сглаживание"
 
-#: data/ui/window.ui:258
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "Свет с HDRI"
 
-#: data/ui/window.ui:259
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr "Освещение сцены с помощью загруженного HDRI"
 
-#: data/ui/window.ui:274
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "Интенсивность света"
 
-#: data/ui/window.ui:283
+#: data/ui/window.ui:327
 msgid "Model Rendering"
 msgstr "Рендеринг модели"
 
-#: data/ui/window.ui:288
+#: data/ui/window.ui:332
 msgid "Show All Edges"
 msgstr "Показывать все грани"
 
-#: data/ui/window.ui:296
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Ширина граней"
 
-#: data/ui/window.ui:318
-msgid "Show Spheres"
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Show Point Sprites"
 msgstr "Показывать вершины"
 
-#: data/ui/window.ui:326
+#: data/ui/window.ui:364
+#, fuzzy
+#| msgid "Points Size"
+msgid "Point Sprites Type"
+msgstr "Размер точек"
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Sphere"
+msgstr "Показывать вершины"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+#, fuzzy
+#| msgid "Points Size"
+msgid "Sprite Size"
+msgstr "Размер точек"
+
+#: data/ui/window.ui:390
 msgid "Points Size"
 msgstr "Размер точек"
 
-#: data/ui/window.ui:350 data/ui/window.ui:364
+#: data/ui/window.ui:413
 msgid "Model"
 msgstr "Модель"
 
-#: data/ui/window.ui:370
-msgid "Load type"
-msgstr "Тип загрузки"
-
-#: data/ui/window.ui:374
-msgid "Geometry"
-msgstr "Геометрия"
-
-#: data/ui/window.ui:375 data/ui/window.ui:491
-msgid "Scene"
-msgstr "Сцена"
-
-#: data/ui/window.ui:388
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "Материал"
 
-#: data/ui/window.ui:393
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "Металлизация модели"
 
-#: data/ui/window.ui:409
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "Шероховатость модели"
 
-#: data/ui/window.ui:426
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "Непрозрачность модели"
 
-#: data/ui/window.ui:444
+#: data/ui/window.ui:483
 msgid "Color"
 msgstr "Цвет"
 
-#: data/ui/window.ui:450
+#: data/ui/window.ui:489
 msgid "Coloration"
 msgstr "Окраска"
 
-#: data/ui/window.ui:454
+#: data/ui/window.ui:493
 msgid "Custom"
 msgstr "Своя"
 
-#: data/ui/window.ui:455
+#: data/ui/window.ui:494
 msgid "Normal"
 msgstr "Обычная"
 
-#: data/ui/window.ui:456
+#: data/ui/window.ui:495
 msgid "Magnitude"
 msgstr "Величина"
 
-#: data/ui/window.ui:457
+#: data/ui/window.ui:496
 msgid "Direct"
 msgstr "Прямая"
 
-#: data/ui/window.ui:467
+#: data/ui/window.ui:506 data/ui/window.ui:513
 msgid "Model Color"
 msgstr "Цвет модели"
 
-#: data/ui/window.ui:505
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "Сцена"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Сетка"
 
-#: data/ui/window.ui:510
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Отображать сетку"
 
-#: data/ui/window.ui:517
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Абсолютное позиционирование сетки"
 
-#: data/ui/window.ui:526
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Фон"
 
-#: data/ui/window.ui:531
+#: data/ui/window.ui:582
 msgid "HDRI as Background"
 msgstr "HDRI как фон"
 
-#: data/ui/window.ui:532
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr "Использовать загруженный HDRI или один из стандартных как фон"
 
-#: data/ui/window.ui:539
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "HDRI изображение"
 
-#: data/ui/window.ui:546
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Размывать фон"
 
-#: data/ui/window.ui:553
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Сила размытия"
 
-#: data/ui/window.ui:575
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Использовать свой цвет"
 
-#: data/ui/window.ui:576
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "HDRI фон имеет приоритет над этим"
 
-#: data/ui/window.ui:583
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Цвет фона"
 
-#: data/ui/window.ui:584
-msgid "Transparent colors not supported"
-msgstr "Прозрачные цвета не поддерживаются"
-
-#: data/ui/window.ui:608
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Еще"
 
-#: data/ui/window.ui:622
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Ориентация"
 
-#: data/ui/window.ui:627
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr "Всегда направлять вверх"
 
-#: data/ui/window.ui:634
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Вертикальное направление"
 
-#: data/ui/window.ui:635
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "При изменении файл будет перезагружен"
 
-#: data/ui/window.ui:639
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr "- X"
 
-#: data/ui/window.ui:640
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr "+ X"
 
-#: data/ui/window.ui:641
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr "- Y"
 
-#: data/ui/window.ui:642
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr "+ Y"
 
-#: data/ui/window.ui:643
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr "- Z"
 
-#: data/ui/window.ui:644
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr "+ Z"
 
-#: data/ui/window.ui:656
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Ориентация"
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
 msgid "Loading"
 msgstr "Загрузка"
 
-#: data/ui/window.ui:661
+#: data/ui/window.ui:761
 msgid "Automatic Settings"
 msgstr "Автоматические настройки"
 
-#: data/ui/window.ui:662
+#: data/ui/window.ui:762
 msgid "When loading choose the best presets for the file"
 msgstr "При загрузке выбирает лучшие настройки для файла"
 
-#: data/ui/window.ui:675
+#: data/ui/window.ui:775
 msgid "Reload On Change"
 msgstr "Перезагрузить при изменении"
 
-#: data/ui/window.ui:676
+#: data/ui/window.ui:776
 msgid "Check for file change"
 msgstr "Проверять файл на изменения"
 
-#: data/ui/window.ui:705
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "Развернуть боковую панель"
 
-#: data/ui/window.ui:731
-msgid "Toggle Orthographic"
-msgstr "Ортографический режим"
-
-#: data/ui/window.ui:739
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr "Сброс"
 
-#: data/ui/window.ui:801
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "Системная тема"
 
-#: data/ui/window.ui:806
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "Светлая тема"
 
-#: data/ui/window.ui:811
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "Темная тема"
 
-#: data/ui/window.ui:816 data/ui/window.ui:866
+#: data/ui/window.ui:926 data/ui/window.ui:990
 msgid "_New Window"
 msgstr "_Новое окно"
 
-#: data/ui/window.ui:822
+#: data/ui/window.ui:930
 msgid "_Load New File"
 msgstr "_Открыть новый файл"
 
-#: data/ui/window.ui:828
+#: data/ui/window.ui:938
 msgid "_Export Image"
 msgstr "_Экспортировать изображение"
 
-#: data/ui/window.ui:834 data/ui/window.ui:872
+#: data/ui/window.ui:942
+#, fuzzy
+#| msgid "Open With External App"
+msgid "_Open In External App"
+msgstr "Открыть через стороннее приложение"
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
 msgid "_Help"
 msgstr "_Cправка"
 
-#: data/ui/window.ui:838 data/ui/window.ui:876
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "_Сочетания клавиш"
 
-#: data/ui/window.ui:842 data/ui/window.ui:880
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr "_О Exhibit"
 
-#: data/ui/window.ui:852
+#: data/ui/window.ui:966
 msgid "Save Current Settings"
 msgstr "Сохранить текущие настройки"
 
-#: data/ui/window.ui:858
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Ортографический режим"
+
+#: data/ui/window.ui:978
 msgid "Open HDRI Folder"
 msgstr "Открыть директорию HDRI"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open HDRI Folder"
+msgid "Open HDRI"
+msgstr "Открыть директорию HDRI"
+
+#~ msgid "Load type"
+#~ msgstr "Тип загрузки"
+
+#~ msgid "Geometry"
+#~ msgstr "Геометрия"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "Прозрачные цвета не поддерживаются"
+
+#~ msgid "Sailing Ship 3d scan rendered as points"
+#~ msgstr "3D-скан плавающего корабля в виде точек"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,14 +1,13 @@
 # Ukrainian translation for Exhibit.
-# Copyright (C) 2024 THE Exhibit COPYRIGHT HOLDER
+# Copyright (C) 2026, Nokse22
 # This file is distributed under the same license as the Exhibit package.
 # volkov <volkovissocool@gmail.com>, 2024.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Exhibit\n"
-"Report-Msgid-Bugs-To: https://github.com/Nokse22/Exhibit/issues\n"
-"POT-Creation-Date: 2024-09-04 15:16+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-02-26 21:13+0100\n"
 "PO-Revision-Date: 2024-09-22 18:50+0300\n"
 "Last-Translator: volkov <volkovissocool@gmail.com>\n"
 "Language-Team: volkov <volkovissocool@gmail.com>\n"
@@ -18,23 +17,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:3
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:848
-#: data/ui/window.ui:11 data/ui/window.ui:77 data/ui/window.ui:155
+#: data/io.github.nokse22.Exhibit.desktop.in:2
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:7 src/window.py:937
+#: data/ui/window.ui:11 data/ui/window.ui:53 data/ui/window.ui:90
+#: data/ui/window.ui:206
 msgid "Exhibit"
 msgstr "Експонат"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:4
+#: data/io.github.nokse22.Exhibit.desktop.in:3
 msgid "3D Model Viewer"
 msgstr "Перегляд 3D-моделей"
 
-#: data/io.github.nokse22.Exhibit.desktop.in:11
-msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+#: data/io.github.nokse22.Exhibit.desktop.in:10
+#, fuzzy
+#| msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;"
+msgid "fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;3d-viewer;"
 msgstr ""
-"fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-model;модель;три;"
-"графіка;обробка;3д;"
+"fbx;step;stl;dcm;ex2;gml;obj;3ds;gltf;pbr;rendering;3d-"
+"model;модель;три;графіка;обробка;3д;"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:73
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:8 data/ui/window.ui:86
 msgid "Preview your 3D models"
 msgstr "Переглядайте ваші 3D-моделі"
 
@@ -57,373 +59,469 @@ msgstr ""
 "прозорість щоб досягти ідеального зображення. Ви можете використовувати HDRI "
 "зображення або колір у якості заднього фону."
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:42
-msgid "3D Bechy"
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#, fuzzy
+#| msgid "3D Bechy"
+msgid "3D Benchy"
 msgstr "3д Bechy"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:46
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:51
 msgid "Retro Computer Setup with a HDRI skybox"
 msgstr "Ретро-комп'ютер з HDRI скайбоксом"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:50
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:56
 msgid "Green Metallic Suzanne"
 msgstr "Зелена металева Сюзанна"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:54
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:61
 msgid "Cow with an HDRI background and dark theme"
 msgstr "Корова з HDRI заднім фоном і темним стилем інтерфейсу"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:58
-msgid "Nissan Fairlady with dark theme"
-msgstr "Nissan Fairlady з темним стилем інтерфейсу"
-
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:62
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
 msgid "Vase 3d scan with HDRI skybox"
 msgstr "3д скан вази з HDRI скайбоксом"
 
-#: data/io.github.nokse22.Exhibit.metainfo.xml.in:66
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:71
 msgid "Point cloud of a boat with dark theme"
 msgstr "Човен з темним стилем інтерфейсу"
 
-#: src/main.py:140
+#: data/io.github.nokse22.Exhibit.metainfo.xml.in:76
+#, fuzzy
+#| msgid "Point cloud of a boat with dark theme"
+msgid "Rigged model showing armature with dark theme"
+msgstr "Човен з темним стилем інтерфейсу"
+
+#: src/main.py:129
 msgid "Checkout F3D"
 msgstr "Дізнатися більше про F3D"
 
-#: src/window.py:713
+#: src/main.py:131
+msgid "Donate with Ko-Fi"
+msgstr ""
+
+#: src/main.py:132
+msgid "Donate with Github"
+msgstr ""
+
+#: src/window.py:817
+msgid "All supported formats"
+msgstr ""
+
+#: src/window.py:826
 msgid "Open File"
 msgstr "Відкрити файл"
 
-#: src/window.py:853
+#: src/window.py:847
+#, fuzzy
+#| msgid "Loading"
+msgid "Loading {}"
+msgstr "Завантаження"
+
+#: src/window.py:917
+#, fuzzy
+#| msgid "Exhibit"
+msgid "Exhibit - {}"
+msgstr "Експонат"
+
+#: src/window.py:942
 msgid "Can't open"
 msgstr "Не вдалося відкрити"
 
-#: src/window.py:869
+#: src/window.py:958
 msgid "Save File"
 msgstr "Зберегти файл"
 
-#: data/ui/window.ui:49 data/ui/window.ui:178 data/ui/window.ui:185
-#: data/ui/window.ui:711
+#: src/window.py:1065
+msgid "Stop"
+msgstr ""
+
+#: src/window.py:1068
+msgid "Start"
+msgstr ""
+
+#: data/ui/window.ui:63 data/ui/window.ui:223 data/ui/window.ui:230
+#: data/ui/window.ui:838
 msgid "Menu"
 msgstr "Меню"
 
-#: data/ui/window.ui:69
+#: data/ui/window.ui:82
 msgid "Load"
 msgstr "Завантажити"
 
-#: data/ui/window.ui:95
+#: data/ui/window.ui:110
 msgid "Try Another"
 msgstr "Спробувати інший"
 
-#: data/ui/window.ui:99
+#: data/ui/window.ui:114
 msgid "Couldn't load the file"
 msgstr "Не вдалося завантажити файл"
 
-#: data/ui/window.ui:103
+#: data/ui/window.ui:118
 msgid "Error Loading File"
 msgstr "Помилка при завантаженні файлу"
 
-#: data/ui/window.ui:161 data/ui/window.ui:719
-msgid "Open With External App"
-msgstr "Відкрити у іншому додатку"
-
-#: data/ui/window.ui:171
+#: data/ui/window.ui:216
 msgid "Close Sidebar"
 msgstr "Закрити бокову панель"
 
-#: data/ui/window.ui:208
+#: data/ui/window.ui:253
 msgid "Render"
 msgstr "Обробка"
 
-#: data/ui/window.ui:222
+#: data/ui/window.ui:267
 msgid "Rendering"
 msgstr "Обробка"
 
-#: data/ui/window.ui:227
+#: data/ui/window.ui:272
 msgid "Translucency"
 msgstr "Прозорість"
 
-#: data/ui/window.ui:234
+#: data/ui/window.ui:279
 msgid "Tone Mapping"
 msgstr "Тональне відображення"
 
-#: data/ui/window.ui:235
+#: data/ui/window.ui:280
 msgid "Map colors properly to the monitor colors"
 msgstr "Належно відображати кольори відносно кольорів монітору"
 
-#: data/ui/window.ui:242
+#: data/ui/window.ui:287
 msgid "Ambient Occlusion"
 msgstr "Ambient Occlusion"
 
-#: data/ui/window.ui:243
+#: data/ui/window.ui:288
 msgid "Provides approximate shadows"
 msgstr "Забезпечує приблизні тіні"
 
-#: data/ui/window.ui:250
+#: data/ui/window.ui:295
 msgid "Anti Aliasing"
 msgstr "Згладження"
 
-#: data/ui/window.ui:257
+#: data/ui/window.ui:302
 msgid "Light with HDRI"
 msgstr "Освітлення з HDRI"
 
-#: data/ui/window.ui:258
+#: data/ui/window.ui:303
 msgid "Light the scene using a the loaded HDRI or the default"
 msgstr "Освітити сцену використовуючи завантажене HDRI або стандартне"
 
-#: data/ui/window.ui:273
+#: data/ui/window.ui:318
 msgid "Light Intensity"
 msgstr "Інтенсивність світла"
 
-#: data/ui/window.ui:282
+#: data/ui/window.ui:327
 msgid "Model Rendering"
 msgstr "Обробка моделі"
 
-#: data/ui/window.ui:287
+#: data/ui/window.ui:332
 msgid "Show All Edges"
 msgstr "Показати всі краї"
 
-#: data/ui/window.ui:294
+#: data/ui/window.ui:339
 msgid "Edges Width"
 msgstr "Ширина країв"
 
-#: data/ui/window.ui:316
-msgid "Show Spheres"
+#: data/ui/window.ui:359
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Show Point Sprites"
 msgstr "Показати сфери"
 
-#: data/ui/window.ui:323
+#: data/ui/window.ui:364
+#, fuzzy
+#| msgid "Points Size"
+msgid "Point Sprites Type"
+msgstr "Розмір точок"
+
+#: data/ui/window.ui:368
+#, fuzzy
+#| msgid "Show Spheres"
+msgid "Sphere"
+msgstr "Показати сфери"
+
+#: data/ui/window.ui:369
+msgid "Gaussian"
+msgstr ""
+
+#: data/ui/window.ui:377
+#, fuzzy
+#| msgid "Points Size"
+msgid "Sprite Size"
+msgstr "Розмір точок"
+
+#: data/ui/window.ui:390
 msgid "Points Size"
 msgstr "Розмір точок"
 
-#: data/ui/window.ui:347 data/ui/window.ui:361
+#: data/ui/window.ui:413
 msgid "Model"
 msgstr "Модель"
 
-#: data/ui/window.ui:367
-msgid "Load type"
-msgstr "Завантажити тип"
-
-#: data/ui/window.ui:371
-msgid "Geometry"
-msgstr "Геометрія"
-
-#: data/ui/window.ui:372 data/ui/window.ui:488
-msgid "Scene"
-msgstr "Сцена"
-
-#: data/ui/window.ui:385
+#: data/ui/window.ui:427
 msgid "Material"
 msgstr "Матеріал"
 
-#: data/ui/window.ui:390
+#: data/ui/window.ui:432
 msgid "Model Metallic"
 msgstr "Металевість моделі"
 
-#: data/ui/window.ui:406
+#: data/ui/window.ui:448
 msgid "Model Roughness"
 msgstr "Жорстокість моделі"
 
-#: data/ui/window.ui:423
+#: data/ui/window.ui:465
 msgid "Model Opacity"
 msgstr "Прозорість моделі"
 
-#: data/ui/window.ui:441
+#: data/ui/window.ui:483
 msgid "Color"
 msgstr "Колір"
 
-#: data/ui/window.ui:447
+#: data/ui/window.ui:489
 msgid "Coloration"
 msgstr "Кольоровість"
 
-#: data/ui/window.ui:451
+#: data/ui/window.ui:493
 msgid "Custom"
 msgstr "Власний"
 
-#: data/ui/window.ui:452
+#: data/ui/window.ui:494
 msgid "Normal"
 msgstr "Нормальна"
 
-#: data/ui/window.ui:453
+#: data/ui/window.ui:495
 msgid "Magnitude"
 msgstr "Величина"
 
-#: data/ui/window.ui:454
+#: data/ui/window.ui:496
 msgid "Direct"
 msgstr "Напряму"
 
-#: data/ui/window.ui:464
+#: data/ui/window.ui:506 data/ui/window.ui:513
 msgid "Model Color"
 msgstr "Колір моделі"
 
-#: data/ui/window.ui:502
+#: data/ui/window.ui:527
+msgid "Show Armature"
+msgstr ""
+
+#: data/ui/window.ui:542
+msgid "Scene"
+msgstr "Сцена"
+
+#: data/ui/window.ui:556
 msgid "Grid"
 msgstr "Ґратка"
 
-#: data/ui/window.ui:507
+#: data/ui/window.ui:561
 msgid "View Grid"
 msgstr "Показати ґратку"
 
-#: data/ui/window.ui:514
+#: data/ui/window.ui:568
 msgid "Grid Absolute"
 msgstr "Ґратка абсолютна"
 
-#: data/ui/window.ui:523
+#: data/ui/window.ui:577
 msgid "Background"
 msgstr "Задній фон"
 
-#: data/ui/window.ui:528
+#: data/ui/window.ui:582
 msgid "HDRI as Background"
 msgstr "HDRI як задній фон"
 
-#: data/ui/window.ui:529
+#: data/ui/window.ui:583
 msgid "Use the loaded HDRI or the default one as a background"
 msgstr ""
 "Використовувати завантажене HDRI або стандартне зображення у якості заднього "
 "фону"
 
-#: data/ui/window.ui:536
+#: data/ui/window.ui:590
 msgid "HDRI Image"
 msgstr "HDRI зображення"
 
-#: data/ui/window.ui:543
+#: data/ui/window.ui:597
 msgid "Blur Background"
 msgstr "Розмити задній фон"
 
-#: data/ui/window.ui:550
+#: data/ui/window.ui:604
 msgid "Blur Circle Of Confusion"
 msgstr "Розмиття"
 
-#: data/ui/window.ui:572
+#: data/ui/window.ui:626
 msgid "Use Custom Color"
 msgstr "Використовувати власний колір"
 
-#: data/ui/window.ui:573
+#: data/ui/window.ui:627
 msgid "HDRI background takes priority over this"
 msgstr "HDRI задній фон отримає більший пріоритет над цим"
 
-#: data/ui/window.ui:580
+#: data/ui/window.ui:634 data/ui/window.ui:641
 msgid "Background Color"
 msgstr "Колір заднього фону"
 
-#: data/ui/window.ui:581
-msgid "Transparent colors not supported"
-msgstr "Прозорі кольори не підтримуються"
-
-#: data/ui/window.ui:605
+#: data/ui/window.ui:661
 msgid "More"
 msgstr "Більше"
 
-#: data/ui/window.ui:619
+#: data/ui/window.ui:675
 msgid "Navigation"
 msgstr "Навігація"
 
-#: data/ui/window.ui:624
+#: data/ui/window.ui:680
 msgid "Always Point Up"
 msgstr "Завжди вказувати вгору"
 
-#: data/ui/window.ui:631
+#: data/ui/window.ui:687
 msgid "Up Direction"
 msgstr "Напрям вгору"
 
-#: data/ui/window.ui:632
+#: data/ui/window.ui:688
 msgid "Changing it will reload the file"
 msgstr "Зміна цього перезавантажить файл"
 
-#: data/ui/window.ui:636
+#: data/ui/window.ui:692
 msgid "- X"
 msgstr ""
 
-#: data/ui/window.ui:637
+#: data/ui/window.ui:693
 msgid "+ X"
 msgstr ""
 
-#: data/ui/window.ui:638
+#: data/ui/window.ui:694
 msgid "- Y"
 msgstr ""
 
-#: data/ui/window.ui:639
+#: data/ui/window.ui:695
 msgid "+ Y"
 msgstr ""
 
-#: data/ui/window.ui:640
+#: data/ui/window.ui:696
 msgid "- Z"
 msgstr ""
 
-#: data/ui/window.ui:641
+#: data/ui/window.ui:697
 msgid "+ Z"
 msgstr ""
 
-#: data/ui/window.ui:653
+#: data/ui/window.ui:707
+#, fuzzy
+#| msgid "Navigation"
+msgid "Animation"
+msgstr "Навігація"
+
+#: data/ui/window.ui:710
+msgid "Animation Index"
+msgstr ""
+
+#: data/ui/window.ui:731
+msgid "Play"
+msgstr ""
+
+#: data/ui/window.ui:756
 msgid "Loading"
 msgstr "Завантаження"
 
-#: data/ui/window.ui:658
+#: data/ui/window.ui:761
 msgid "Automatic Settings"
 msgstr "Автоматичні налаштування"
 
-#: data/ui/window.ui:659
+#: data/ui/window.ui:762
 msgid "When loading choose the best presets for the file"
 msgstr "При завантаженні обирати найкращі налаштування для файлу"
 
-#: data/ui/window.ui:672
+#: data/ui/window.ui:775
 msgid "Reload On Change"
 msgstr "Перезавантажити при змінах"
 
-#: data/ui/window.ui:673
+#: data/ui/window.ui:776
 msgid "Check for file change"
 msgstr "Перевірити файл на зміни"
 
-#: data/ui/window.ui:702
+#: data/ui/window.ui:826
 msgid "Reveal Sidebar"
 msgstr "Показати бокову панель"
 
-#: data/ui/window.ui:728
-msgid "Toggle Orthographic"
-msgstr "Перемикнути на ортографічний перегляд"
-
-#: data/ui/window.ui:736
+#: data/ui/window.ui:849
 msgid "Reset to Bounds"
 msgstr "Скинути до меж"
 
-#: data/ui/window.ui:798
+#: data/ui/window.ui:911
 msgid "Follow System"
 msgstr "Системний стиль"
 
-#: data/ui/window.ui:803
+#: data/ui/window.ui:916
 msgid "Light Theme"
 msgstr "Світлий стиль"
 
-#: data/ui/window.ui:808
+#: data/ui/window.ui:921
 msgid "Dark Theme"
 msgstr "Темний стиль"
 
-#: data/ui/window.ui:813 data/ui/window.ui:863
+#: data/ui/window.ui:926 data/ui/window.ui:990
 msgid "_New Window"
 msgstr "_Нове вікно"
 
-#: data/ui/window.ui:819
+#: data/ui/window.ui:930
 msgid "_Load New File"
 msgstr "_Завантажити новий файл"
 
-#: data/ui/window.ui:825
+#: data/ui/window.ui:938
 msgid "_Export Image"
 msgstr "_Експортувати зображення"
 
-#: data/ui/window.ui:831 data/ui/window.ui:869
+#: data/ui/window.ui:942
+#, fuzzy
+#| msgid "Open With External App"
+msgid "_Open In External App"
+msgstr "Відкрити у іншому додатку"
+
+#: data/ui/window.ui:948 data/ui/window.ui:996
 msgid "_Help"
 msgstr "_Допомога"
 
-#: data/ui/window.ui:835 data/ui/window.ui:873
+#: data/ui/window.ui:952 data/ui/window.ui:1000
 msgid "_Keyboard Shortcuts"
 msgstr "_Клавіатурні скорочення"
 
-#: data/ui/window.ui:839 data/ui/window.ui:877
+#: data/ui/window.ui:956 data/ui/window.ui:1004
 msgid "_About Exhibit"
 msgstr "_Про Експонат"
 
-#: data/ui/window.ui:849
+#: data/ui/window.ui:966
 msgid "Save Current Settings"
 msgstr "Зберегти поточні налаштування"
 
-#: data/ui/window.ui:855
+#: data/ui/window.ui:972
+#, fuzzy
+#| msgid "Toggle Orthographic"
+msgid "Orthonographic"
+msgstr "Перемикнути на ортографічний перегляд"
+
+#: data/ui/window.ui:978
 msgid "Open HDRI Folder"
 msgstr "Відкрити HDRI теку"
+
+#: data/ui/window.ui:982
+msgid "Open Configurations Folder"
+msgstr ""
+
+#: data/ui/window.ui:1037
+msgid "Comma separated list of the supported extensions"
+msgstr ""
+
+#: data/ui/file_row.ui:83
+#, fuzzy
+#| msgid "Open HDRI Folder"
+msgid "Open HDRI"
+msgstr "Відкрити HDRI теку"
+
+#~ msgid "Nissan Fairlady with dark theme"
+#~ msgstr "Nissan Fairlady з темним стилем інтерфейсу"
+
+#~ msgid "Load type"
+#~ msgstr "Завантажити тип"
+
+#~ msgid "Geometry"
+#~ msgstr "Геометрія"
+
+#~ msgid "Transparent colors not supported"
+#~ msgstr "Прозорі кольори не підтримуються"

--- a/update_translations.sh
+++ b/update_translations.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Originally from the Cine Video Player by diegopvlk
+
+OUTPUT="po/Exhibit.pot"
+PACKAGE_NAME="Exhibit"
+ENCODING="UTF-8"
+LANGUAGE_BLP="--language=JavaScript"
+LINGUAS_FILE="po/LINGUAS"
+
+grep -v '\.blp$' po/POTFILES > /tmp/TEMP_POTFILES
+grep '\.blp$' po/POTFILES > /tmp/TEMP_POTFILES.blp
+
+# Creates pot
+xgettext --files-from=/tmp/TEMP_POTFILES \
+       	 --output="$OUTPUT" --package-name="$PACKAGE_NAME" \
+       	 --from-code="$ENCODING" --add-comments \
+       	 --keyword=_ --keyword=C_:1c,2
+
+# Joins pot
+xgettext --files-from=/tmp/TEMP_POTFILES.blp \
+    	 --output="$OUTPUT" --package-name="$PACKAGE_NAME" \
+    	 --from-code="$ENCODING" --add-comments \
+    	 --keyword=_ --keyword=C_:1c,2 \
+    	 $LANGUAGE_BLP \
+    	 --join-existing
+
+
+rm /tmp/TEMP_POTFILES /tmp/TEMP_POTFILES.blp
+
+sed -i 's/charset=CHARSET/charset=UTF-8/g' $OUTPUT
+
+grep -v '^#' "$LINGUAS_FILE" | while read -r lang_file; do
+    msgmerge --previous --backup=none --update "po/${lang_file}.po" "$OUTPUT" \
+    || echo "Error with : $lang_file" >&2
+done


### PR DESCRIPTION
Hello ! 

I'm Mimolet, a French translator mostly known for translating Bazaar.
As I'm working with games for my studies, and wanted to preview 3D models.
I discovered your app, but the French translation wasn't up to date. 
So I wanted to update that translation.

As you may guess, I did a bit more than that, here's a recap of my changes : 
- Metainfo : I wanted to fix a typo with Benchy (it was written "Bechy"), but then my text editor realigned stuff around, so I cleaned it up a bit
- update_translations.sh : I added a script to update the translation files. It was originally written for the Cine video player (another project on which I did the French translation), but I changed a few things to make it work for Exhibit - if you have an issue with it, we can simply remove it
- All the translations : I refreshed all the .po files (most of them haven't been updated since 2024), making sure they got correct infos and reordered the LINGUAS because `fr` wasn't at the right place
- French translation : At last, I updated the French translation 

I've also noticed the view presets aren't translatable - I know it's because of technical reasons, because they come from a JSON file, but at least now you know (it's not urgent)

I hope it isn't too much,

Have a nice day,
Mimolet