### PR TITLE
feat: decompress meshopt + dequantize KHR_mesh_quantization before load

### DIFF
--- a/build-aux/io.github.nokse22.Exhibit.json
+++ b/build-aux/io.github.nokse22.Exhibit.json
@@ -8,7 +8,9 @@
         "--share=ipc",
         "--socket=wayland",
         "--socket=fallback-x11",
-        "--device=dri"
+        "--device=dri",
+        "--filesystem=home",
+        "--filesystem=/tmp"
     ],
     "cleanup" : [
         "/include",

--- a/build-aux/io.github.nokse22.Exhibit.json
+++ b/build-aux/io.github.nokse22.Exhibit.json
@@ -24,6 +24,24 @@
         "imagemagick.json",
         "libf3d.json",
         {
+            "name": "meshoptimizer",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DMESHOPT_BUILD_SHARED_LIBS=ON",
+                "-DMESHOPT_BUILD_DEMO=OFF",
+                "-DMESHOPT_BUILD_GLTFPACK=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/zeux/meshoptimizer/archive/refs/tags/v1.2.tar.gz",
+                    "sha256": "e40f71b809cdf3361b9a4def85fd44534e8733ce29d4b943c145b76859e4c2b4"
+                }
+            ]
+        },
+        {
             "name" : "exhibit",
             "buildsystem" : "meson",
             "config-opts" : [

--- a/src/meshopt_decompress.py
+++ b/src/meshopt_decompress.py
@@ -1,0 +1,412 @@
+# meshopt_decompress.py
+#
+# Copyright 2024-2025 Nokse <nokse@posteo.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Decompress GLBs that use EXT/KHR_meshopt_compression before F3D/VTK load."""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import tempfile
+from ctypes import (
+    CDLL,
+    POINTER,
+    c_int,
+    c_size_t,
+    c_ubyte,
+    c_void_p,
+    cast,
+)
+from ctypes.util import find_library
+from typing import Any
+
+MESHOPT_EXTENSIONS = (
+    "EXT_meshopt_compression",
+    "KHR_meshopt_compression",
+)
+
+_GLB_MAGIC = 0x46546C67
+_CHUNK_JSON = 0x4E4F534A
+_CHUNK_BIN = 0x004E4942
+
+_lib: CDLL | None = None
+_lib_failed = False
+
+
+class MeshoptError(Exception):
+    """Raised when a meshopt-compressed GLB cannot be decompressed."""
+
+
+def _load_library() -> CDLL:
+    global _lib, _lib_failed
+    if _lib is not None:
+        return _lib
+    if _lib_failed:
+        raise MeshoptError("libmeshoptimizer is not available")
+
+    candidates = [
+        "meshoptimizer",
+        "libmeshoptimizer.so",
+        "/app/lib/libmeshoptimizer.so",
+        "/usr/lib/libmeshoptimizer.so",
+        "/usr/local/lib/libmeshoptimizer.so",
+    ]
+    found = find_library("meshoptimizer")
+    if found:
+        candidates.insert(0, found)
+
+    last_error: Exception | None = None
+    for name in candidates:
+        try:
+            lib = CDLL(name)
+        except OSError as exc:
+            last_error = exc
+            continue
+        _configure_lib(lib)
+        _lib = lib
+        return lib
+
+    _lib_failed = True
+    raise MeshoptError(
+        "libmeshoptimizer is not available; cannot open meshopt-compressed GLB"
+    ) from last_error
+
+
+def _configure_lib(lib: CDLL) -> None:
+    lib.meshopt_decodeVertexBuffer.argtypes = [
+        c_void_p,
+        c_size_t,
+        c_size_t,
+        POINTER(c_ubyte),
+        c_size_t,
+    ]
+    lib.meshopt_decodeVertexBuffer.restype = c_int
+
+    lib.meshopt_decodeIndexBuffer.argtypes = [
+        c_void_p,
+        c_size_t,
+        c_size_t,
+        POINTER(c_ubyte),
+        c_size_t,
+    ]
+    lib.meshopt_decodeIndexBuffer.restype = c_int
+
+    lib.meshopt_decodeIndexSequence.argtypes = [
+        c_void_p,
+        c_size_t,
+        c_size_t,
+        POINTER(c_ubyte),
+        c_size_t,
+    ]
+    lib.meshopt_decodeIndexSequence.restype = c_int
+
+    for filter_name in (
+        "meshopt_decodeFilterOct",
+        "meshopt_decodeFilterQuat",
+        "meshopt_decodeFilterExp",
+        "meshopt_decodeFilterColor",
+    ):
+        fn = getattr(lib, filter_name)
+        fn.argtypes = [c_void_p, c_size_t, c_size_t]
+        fn.restype = None
+
+
+def _read_glb(path: str) -> tuple[dict[str, Any], bytes]:
+    with open(path, "rb") as handle:
+        data = handle.read()
+
+    if len(data) < 12:
+        raise MeshoptError(f"File too small to be a GLB: {path}")
+
+    magic, version, length = struct.unpack_from("<III", data, 0)
+    if magic != _GLB_MAGIC:
+        raise MeshoptError(f"Not a GLB file: {path}")
+    if version != 2:
+        raise MeshoptError(f"Unsupported GLB version {version}: {path}")
+    if length > len(data):
+        raise MeshoptError(f"Truncated GLB: {path}")
+
+    offset = 12
+    json_chunk: bytes | None = None
+    bin_chunk = b""
+
+    while offset + 8 <= len(data):
+        chunk_length, chunk_type = struct.unpack_from("<II", data, offset)
+        offset += 8
+        chunk_data = data[offset : offset + chunk_length]
+        offset += chunk_length
+        if chunk_type == _CHUNK_JSON:
+            json_chunk = chunk_data
+        elif chunk_type == _CHUNK_BIN:
+            bin_chunk = chunk_data
+
+    if json_chunk is None:
+        raise MeshoptError(f"GLB missing JSON chunk: {path}")
+
+    try:
+        gltf = json.loads(json_chunk.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MeshoptError(f"Invalid GLB JSON chunk: {path}") from exc
+
+    return gltf, bin_chunk
+
+
+def _write_glb(path: str, gltf: dict[str, Any], bin_chunk: bytes) -> None:
+    json_bytes = json.dumps(gltf, separators=(",", ":")).encode("utf-8")
+    json_padding = (4 - (len(json_bytes) % 4)) % 4
+    json_bytes += b" " * json_padding
+
+    bin_padding = (4 - (len(bin_chunk) % 4)) % 4
+    bin_bytes = bin_chunk + (b"\x00" * bin_padding)
+
+    total = 12 + 8 + len(json_bytes) + 8 + len(bin_bytes)
+    with open(path, "wb") as handle:
+        handle.write(struct.pack("<III", _GLB_MAGIC, 2, total))
+        handle.write(struct.pack("<II", len(json_bytes), _CHUNK_JSON))
+        handle.write(json_bytes)
+        handle.write(struct.pack("<II", len(bin_bytes), _CHUNK_BIN))
+        handle.write(bin_bytes)
+
+
+def _extension_on_view(view: dict[str, Any]) -> dict[str, Any] | None:
+    extensions = view.get("extensions") or {}
+    for name in MESHOPT_EXTENSIONS:
+        ext = extensions.get(name)
+        if isinstance(ext, dict):
+            return ext
+    return None
+
+
+def _is_fallback_buffer(buffer_def: dict[str, Any]) -> bool:
+    extensions = buffer_def.get("extensions") or {}
+    for name in MESHOPT_EXTENSIONS:
+        ext = extensions.get(name)
+        if isinstance(ext, dict) and ext.get("fallback"):
+            return True
+    return False
+
+
+def needs_meshopt_decompress(path: str) -> bool:
+    """Return True if path is a GLB that uses meshopt bufferView compression."""
+    if not path or not str(path).lower().endswith(".glb"):
+        return False
+    try:
+        gltf, _bin = _read_glb(path)
+    except (OSError, MeshoptError):
+        return False
+
+    for view in gltf.get("bufferViews") or []:
+        if _extension_on_view(view):
+            return True
+
+    required = gltf.get("extensionsRequired") or []
+    return any(name in required for name in MESHOPT_EXTENSIONS)
+
+
+def _buffer_payloads(gltf: dict[str, Any], bin_chunk: bytes) -> list[bytes | None]:
+    buffers = gltf.get("buffers") or []
+    payloads: list[bytes | None] = []
+    for index, buffer_def in enumerate(buffers):
+        if _is_fallback_buffer(buffer_def):
+            payloads.append(None)
+            continue
+        uri = buffer_def.get("uri")
+        if uri:
+            raise MeshoptError(
+                "meshopt decompress supports self-contained .glb only "
+                f"(buffer {index} has uri)"
+            )
+        # GLB binary chunk is buffer 0 when uri is omitted.
+        if index == 0:
+            payloads.append(bin_chunk)
+        else:
+            # Placeholder buffer without fallback flag and without uri.
+            payloads.append(None)
+    return payloads
+
+
+def _decode_view(lib: CDLL, source: bytes, ext: dict[str, Any]) -> bytes:
+    mode = ext.get("mode")
+    filter_name = ext.get("filter") or "NONE"
+    count = int(ext["count"])
+    stride = int(ext["byteStride"])
+    if count < 0 or stride <= 0:
+        raise MeshoptError("Invalid meshopt bufferView parameters")
+
+    destination = (c_ubyte * (count * stride))()
+    source_buf = (c_ubyte * len(source)).from_buffer_copy(source)
+
+    decoders = {
+        "ATTRIBUTES": lib.meshopt_decodeVertexBuffer,
+        "TRIANGLES": lib.meshopt_decodeIndexBuffer,
+        "INDICES": lib.meshopt_decodeIndexSequence,
+    }
+    decode_fn = decoders.get(mode)
+    if decode_fn is None:
+        raise MeshoptError(f"Unsupported meshopt mode: {mode}")
+
+    result = decode_fn(destination, count, stride, source_buf, len(source))
+    if result != 0:
+        raise MeshoptError(f"meshopt decode failed (mode={mode}, code={result})")
+
+    filters = {
+        "NONE": None,
+        "OCTAHEDRAL": lib.meshopt_decodeFilterOct,
+        "QUATERNION": lib.meshopt_decodeFilterQuat,
+        "EXPONENTIAL": lib.meshopt_decodeFilterExp,
+        "COLOR": lib.meshopt_decodeFilterColor,
+    }
+    if filter_name not in filters:
+        raise MeshoptError(f"Unsupported meshopt filter: {filter_name}")
+
+    filter_fn = filters[filter_name]
+    if filter_fn is not None:
+        # Match meshoptimizer JS decoder: round count up to multiple of 4.
+        count4 = (count + 3) & ~3
+        filter_fn(cast(destination, c_void_p), count4, stride)
+
+    return bytes(destination)
+
+
+def _align4(value: int) -> int:
+    return (value + 3) & ~3
+
+
+def decompress_glb(path: str) -> str:
+    """
+    Return a path to a GLB without meshopt compression.
+
+    If decompression is unnecessary, returns ``path``. Otherwise writes a
+    temporary ``.glb`` and returns that path. Caller should delete temps via
+    ``cleanup_decompressed``.
+    """
+    if not needs_meshopt_decompress(path):
+        return path
+
+    lib = _load_library()
+    gltf, bin_chunk = _read_glb(path)
+    payloads = _buffer_payloads(gltf, bin_chunk)
+
+    new_bin = bytearray()
+    new_views: list[dict[str, Any]] = []
+
+    for view in gltf.get("bufferViews") or []:
+        ext = _extension_on_view(view)
+        if ext is not None:
+            src_buffer = int(ext["buffer"])
+            src_offset = int(ext.get("byteOffset") or 0)
+            src_length = int(ext["byteLength"])
+            payload = payloads[src_buffer] if 0 <= src_buffer < len(payloads) else None
+            if payload is None:
+                raise MeshoptError(
+                    f"Missing compressed buffer data for buffer {src_buffer}"
+                )
+            source = payload[src_offset : src_offset + src_length]
+            if len(source) != src_length:
+                raise MeshoptError("Compressed bufferView data is truncated")
+            decoded = _decode_view(lib, source, ext)
+        else:
+            src_buffer = int(view.get("buffer", 0))
+            src_offset = int(view.get("byteOffset") or 0)
+            src_length = int(view["byteLength"])
+            payload = payloads[src_buffer] if 0 <= src_buffer < len(payloads) else None
+            if payload is None:
+                raise MeshoptError(
+                    f"Missing buffer data for uncompressed bufferView "
+                    f"(buffer {src_buffer})"
+                )
+            decoded = payload[src_offset : src_offset + src_length]
+            if len(decoded) != src_length:
+                raise MeshoptError("Uncompressed bufferView data is truncated")
+
+        padding = _align4(len(new_bin)) - len(new_bin)
+        if padding:
+            new_bin.extend(b"\x00" * padding)
+
+        new_view = {
+            key: value
+            for key, value in view.items()
+            if key not in ("buffer", "byteOffset", "byteLength", "extensions")
+        }
+        new_view["buffer"] = 0
+        new_view["byteOffset"] = len(new_bin)
+        new_view["byteLength"] = len(decoded)
+
+        # Preserve parent extensions except meshopt.
+        old_ext = view.get("extensions")
+        if old_ext:
+            kept = {
+                name: value
+                for name, value in old_ext.items()
+                if name not in MESHOPT_EXTENSIONS
+            }
+            if kept:
+                new_view["extensions"] = kept
+
+        new_bin.extend(decoded)
+        new_views.append(new_view)
+
+    gltf["bufferViews"] = new_views
+    gltf["buffers"] = [{"byteLength": len(new_bin)}]
+
+    for key in ("extensionsUsed", "extensionsRequired"):
+        values = gltf.get(key)
+        if not values:
+            continue
+        filtered = [name for name in values if name not in MESHOPT_EXTENSIONS]
+        if filtered:
+            gltf[key] = filtered
+        else:
+            del gltf[key]
+
+    # Drop top-level meshopt extension objects if present.
+    top_ext = gltf.get("extensions")
+    if top_ext:
+        for name in MESHOPT_EXTENSIONS:
+            top_ext.pop(name, None)
+        if not top_ext:
+            del gltf["extensions"]
+
+    fd, temp_path = tempfile.mkstemp(prefix="exhibit-meshopt-", suffix=".glb")
+    os.close(fd)
+    try:
+        _write_glb(temp_path, gltf, bytes(new_bin))
+    except Exception:
+        cleanup_decompressed(temp_path)
+        raise
+    return temp_path
+
+
+def cleanup_decompressed(path: str | None) -> None:
+    """Delete a temporary GLB created by ``decompress_glb``."""
+    if not path:
+        return
+    try:
+        if os.path.basename(path).startswith("exhibit-meshopt-"):
+            os.unlink(path)
+    except OSError:
+        pass
+
+
+def prepare_glb_for_load(path: str) -> tuple[str, str | None]:
+    """
+    Prepare a path for F3D.
+
+    Returns ``(load_path, temp_path)``. ``temp_path`` is set when a temporary
+    decompressed file was created and must be cleaned up by the caller.
+    """
+    if not needs_meshopt_decompress(path):
+        return path, None
+    load_path = decompress_glb(path)
+    if load_path == path:
+        return path, None
+    return load_path, load_path

--- a/src/meshopt_decompress.py
+++ b/src/meshopt_decompress.py
@@ -9,11 +9,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Decompress GLBs that use EXT/KHR_meshopt_compression before F3D/VTK load."""
+"""Prepare GLBs for F3D/VTK by expanding meshopt + KHR_mesh_quantization."""
 
 from __future__ import annotations
 
 import json
+import math
 import os
 import struct
 import tempfile
@@ -33,17 +34,45 @@ MESHOPT_EXTENSIONS = (
     "EXT_meshopt_compression",
     "KHR_meshopt_compression",
 )
+QUANTIZATION_EXTENSION = "KHR_mesh_quantization"
 
 _GLB_MAGIC = 0x46546C67
 _CHUNK_JSON = 0x4E4F534A
 _CHUNK_BIN = 0x004E4942
+
+_COMPONENT_SIZE = {
+    5120: 1,  # BYTE
+    5121: 1,  # UNSIGNED_BYTE
+    5122: 2,  # SHORT
+    5123: 2,  # UNSIGNED_SHORT
+    5125: 4,  # UNSIGNED_INT
+    5126: 4,  # FLOAT
+}
+_COMPONENT_STRUCT = {
+    5120: "b",
+    5121: "B",
+    5122: "h",
+    5123: "H",
+    5125: "I",
+    5126: "f",
+}
+_TYPE_COUNT = {
+    "SCALAR": 1,
+    "VEC2": 2,
+    "VEC3": 3,
+    "VEC4": 4,
+    "MAT2": 4,
+    "MAT3": 9,
+    "MAT4": 16,
+}
+_FLOAT = 5126
 
 _lib: CDLL | None = None
 _lib_failed = False
 
 
 class MeshoptError(Exception):
-    """Raised when a meshopt-compressed GLB cannot be decompressed."""
+    """Raised when a GLB cannot be prepared for load."""
 
 
 def _load_library() -> CDLL:
@@ -195,21 +224,34 @@ def _is_fallback_buffer(buffer_def: dict[str, Any]) -> bool:
     return False
 
 
+def _lists_extension(gltf: dict[str, Any], name: str) -> bool:
+    for key in ("extensionsRequired", "extensionsUsed"):
+        values = gltf.get(key) or []
+        if name in values:
+            return True
+    return False
+
+
+def _gltf_has_meshopt(gltf: dict[str, Any]) -> bool:
+    for view in gltf.get("bufferViews") or []:
+        if _extension_on_view(view):
+            return True
+    return any(_lists_extension(gltf, name) for name in MESHOPT_EXTENSIONS)
+
+
+def _gltf_has_quantization(gltf: dict[str, Any]) -> bool:
+    return _lists_extension(gltf, QUANTIZATION_EXTENSION)
+
+
 def needs_meshopt_decompress(path: str) -> bool:
-    """Return True if path is a GLB that uses meshopt bufferView compression."""
+    """Return True if path is a GLB that needs meshopt and/or dequantization."""
     if not path or not str(path).lower().endswith(".glb"):
         return False
     try:
         gltf, _bin = _read_glb(path)
     except (OSError, MeshoptError):
         return False
-
-    for view in gltf.get("bufferViews") or []:
-        if _extension_on_view(view):
-            return True
-
-    required = gltf.get("extensionsRequired") or []
-    return any(name in required for name in MESHOPT_EXTENSIONS)
+    return _gltf_has_meshopt(gltf) or _gltf_has_quantization(gltf)
 
 
 def _buffer_payloads(gltf: dict[str, Any], bin_chunk: bytes) -> list[bytes | None]:
@@ -281,19 +323,37 @@ def _align4(value: int) -> int:
     return (value + 3) & ~3
 
 
-def decompress_glb(path: str) -> str:
-    """
-    Return a path to a GLB without meshopt compression.
+def _append_bytes(dest: bytearray, payload: bytes) -> int:
+    padding = _align4(len(dest)) - len(dest)
+    if padding:
+        dest.extend(b"\x00" * padding)
+    offset = len(dest)
+    dest.extend(payload)
+    return offset
 
-    If decompression is unnecessary, returns ``path``. Otherwise writes a
-    temporary ``.glb`` and returns that path. Caller should delete temps via
-    ``cleanup_decompressed``.
-    """
-    if not needs_meshopt_decompress(path):
-        return path
 
+def _strip_extensions(gltf: dict[str, Any], names: tuple[str, ...] | list[str]) -> None:
+    drop = set(names)
+    for key in ("extensionsUsed", "extensionsRequired"):
+        values = gltf.get(key)
+        if not values:
+            continue
+        filtered = [name for name in values if name not in drop]
+        if filtered:
+            gltf[key] = filtered
+        else:
+            del gltf[key]
+
+    top_ext = gltf.get("extensions")
+    if top_ext:
+        for name in drop:
+            top_ext.pop(name, None)
+        if not top_ext:
+            del gltf["extensions"]
+
+
+def _decompress_meshopt(gltf: dict[str, Any], bin_chunk: bytes) -> bytes:
     lib = _load_library()
-    gltf, bin_chunk = _read_glb(path)
     payloads = _buffer_payloads(gltf, bin_chunk)
 
     new_bin = bytearray()
@@ -328,20 +388,15 @@ def decompress_glb(path: str) -> str:
             if len(decoded) != src_length:
                 raise MeshoptError("Uncompressed bufferView data is truncated")
 
-        padding = _align4(len(new_bin)) - len(new_bin)
-        if padding:
-            new_bin.extend(b"\x00" * padding)
-
         new_view = {
             key: value
             for key, value in view.items()
             if key not in ("buffer", "byteOffset", "byteLength", "extensions")
         }
         new_view["buffer"] = 0
-        new_view["byteOffset"] = len(new_bin)
+        new_view["byteOffset"] = _append_bytes(new_bin, decoded)
         new_view["byteLength"] = len(decoded)
 
-        # Preserve parent extensions except meshopt.
         old_ext = view.get("extensions")
         if old_ext:
             kept = {
@@ -352,34 +407,235 @@ def decompress_glb(path: str) -> str:
             if kept:
                 new_view["extensions"] = kept
 
-        new_bin.extend(decoded)
         new_views.append(new_view)
 
     gltf["bufferViews"] = new_views
     gltf["buffers"] = [{"byteLength": len(new_bin)}]
+    _strip_extensions(gltf, MESHOPT_EXTENSIONS)
+    return bytes(new_bin)
 
-    for key in ("extensionsUsed", "extensionsRequired"):
-        values = gltf.get(key)
-        if not values:
+
+def _should_dequant_attr(name: str) -> bool:
+    if name in ("POSITION", "NORMAL", "TANGENT"):
+        return True
+    return name.startswith("TEXCOORD_")
+
+
+def _collect_dequant_accessors(gltf: dict[str, Any]) -> set[int]:
+    result: set[int] = set()
+    for mesh in gltf.get("meshes") or []:
+        for prim in mesh.get("primitives") or []:
+            for name, accessor_index in (prim.get("attributes") or {}).items():
+                if _should_dequant_attr(name):
+                    result.add(int(accessor_index))
+            for target in prim.get("targets") or []:
+                for name, accessor_index in target.items():
+                    if _should_dequant_attr(name):
+                        result.add(int(accessor_index))
+    return result
+
+
+def _dequant_scalar(value: int | float, component_type: int, normalized: bool) -> float:
+    if component_type == _FLOAT:
+        return float(value)
+    ivalue = int(value)
+    if not normalized:
+        return float(ivalue)
+    if component_type == 5120:
+        return max(ivalue / 127.0, -1.0)
+    if component_type == 5121:
+        return ivalue / 255.0
+    if component_type == 5122:
+        return max(ivalue / 32767.0, -1.0)
+    if component_type == 5123:
+        return ivalue / 65535.0
+    raise MeshoptError(
+        f"Unsupported quantized componentType for dequantization: {component_type}"
+    )
+
+
+def _accessor_stride(accessor: dict[str, Any], view: dict[str, Any]) -> int:
+    component_type = int(accessor["componentType"])
+    type_name = accessor["type"]
+    if type_name not in _TYPE_COUNT or component_type not in _COMPONENT_SIZE:
+        raise MeshoptError("Unsupported accessor type for dequantization")
+    default = _TYPE_COUNT[type_name] * _COMPONENT_SIZE[component_type]
+    stride = view.get("byteStride")
+    if stride is None:
+        return default
+    stride_i = int(stride)
+    if stride_i < default:
+        raise MeshoptError("Invalid accessor byteStride")
+    return stride_i
+
+
+def _read_accessor_floats(
+    gltf: dict[str, Any], bin_chunk: bytes, accessor: dict[str, Any]
+) -> list[float]:
+    if "bufferView" not in accessor:
+        raise MeshoptError("Sparse-only accessors are not supported for dequantization")
+
+    view = (gltf.get("bufferViews") or [])[int(accessor["bufferView"])]
+    component_type = int(accessor["componentType"])
+    type_name = accessor["type"]
+    count = int(accessor["count"])
+    normalized = bool(accessor.get("normalized"))
+    ncomp = _TYPE_COUNT[type_name]
+    fmt = _COMPONENT_STRUCT[component_type]
+    stride = _accessor_stride(accessor, view)
+    base = int(view.get("byteOffset") or 0) + int(accessor.get("byteOffset") or 0)
+
+    values: list[float] = []
+    for index in range(count):
+        offset = base + index * stride
+        comps = struct.unpack_from("<" + fmt * ncomp, bin_chunk, offset)
+        for comp in comps:
+            values.append(_dequant_scalar(comp, component_type, normalized))
+    return values
+
+
+def _copy_view_bytes(view: dict[str, Any], bin_chunk: bytes) -> bytes:
+    src_offset = int(view.get("byteOffset") or 0)
+    src_length = int(view["byteLength"])
+    payload = bin_chunk[src_offset : src_offset + src_length]
+    if len(payload) != src_length:
+        raise MeshoptError("bufferView data is truncated")
+    return payload
+
+
+def _dequant_mesh_quantization(gltf: dict[str, Any], bin_chunk: bytes) -> bytes:
+    accessors = gltf.get("accessors") or []
+    buffer_views = gltf.get("bufferViews") or []
+    dequant_accessors = {
+        index
+        for index in _collect_dequant_accessors(gltf)
+        if 0 <= index < len(accessors)
+        and int(accessors[index].get("componentType", _FLOAT)) != _FLOAT
+    }
+
+    if not dequant_accessors and not _gltf_has_quantization(gltf):
+        return bin_chunk
+
+    raw_views: set[int] = set()
+    for image in gltf.get("images") or []:
+        if "bufferView" in image:
+            raw_views.add(int(image["bufferView"]))
+    for index, accessor in enumerate(accessors):
+        if index in dequant_accessors:
             continue
-        filtered = [name for name in values if name not in MESHOPT_EXTENSIONS]
-        if filtered:
-            gltf[key] = filtered
-        else:
-            del gltf[key]
+        if "bufferView" in accessor:
+            raw_views.add(int(accessor["bufferView"]))
 
-    # Drop top-level meshopt extension objects if present.
-    top_ext = gltf.get("extensions")
-    if top_ext:
-        for name in MESHOPT_EXTENSIONS:
-            top_ext.pop(name, None)
-        if not top_ext:
-            del gltf["extensions"]
+    new_bin = bytearray()
+    new_views: list[dict[str, Any]] = []
+    view_remap: dict[int, int] = {}
+
+    for old_index in sorted(raw_views):
+        if old_index < 0 or old_index >= len(buffer_views):
+            raise MeshoptError(f"Invalid bufferView index {old_index}")
+        old_view = buffer_views[old_index]
+        payload = _copy_view_bytes(old_view, bin_chunk)
+        new_view = {
+            key: value
+            for key, value in old_view.items()
+            if key not in ("buffer", "byteOffset", "byteLength")
+        }
+        new_view["buffer"] = 0
+        new_view["byteOffset"] = _append_bytes(new_bin, payload)
+        new_view["byteLength"] = len(payload)
+        view_remap[old_index] = len(new_views)
+        new_views.append(new_view)
+
+    for image in gltf.get("images") or []:
+        if "bufferView" in image:
+            image["bufferView"] = view_remap[int(image["bufferView"])]
+
+    for index, accessor in enumerate(accessors):
+        if index in dequant_accessors:
+            continue
+        if "bufferView" not in accessor:
+            continue
+        accessor["bufferView"] = view_remap[int(accessor["bufferView"])]
+
+    for index in sorted(dequant_accessors):
+        accessor = accessors[index]
+        floats = _read_accessor_floats(gltf, bin_chunk, accessor)
+        payload = struct.pack("<" + "f" * len(floats), *floats)
+        ncomp = _TYPE_COUNT[accessor["type"]]
+
+        new_view = {
+            "buffer": 0,
+            "byteOffset": _append_bytes(new_bin, payload),
+            "byteLength": len(payload),
+            "byteStride": ncomp * 4,
+            "target": 34962,  # ARRAY_BUFFER
+        }
+        # Preserve target from old view when present.
+        old_view_index = int(accessor["bufferView"])
+        if 0 <= old_view_index < len(buffer_views):
+            old_target = buffer_views[old_view_index].get("target")
+            if old_target is not None:
+                new_view["target"] = old_target
+
+        accessor["bufferView"] = len(new_views)
+        accessor["byteOffset"] = 0
+        accessor["componentType"] = _FLOAT
+        accessor.pop("normalized", None)
+
+        # min/max in quantized files are in the quantized domain; rewrite from floats.
+        if floats and ("min" in accessor or "max" in accessor):
+            mins = [math.inf] * ncomp
+            maxs = [-math.inf] * ncomp
+            for row in range(int(accessor["count"])):
+                base = row * ncomp
+                for comp_i in range(ncomp):
+                    value = floats[base + comp_i]
+                    if value < mins[comp_i]:
+                        mins[comp_i] = value
+                    if value > maxs[comp_i]:
+                        maxs[comp_i] = value
+            if "min" in accessor:
+                accessor["min"] = mins
+            if "max" in accessor:
+                accessor["max"] = maxs
+
+        new_views.append(new_view)
+
+    gltf["bufferViews"] = new_views
+    gltf["buffers"] = [{"byteLength": len(new_bin)}]
+    _strip_extensions(gltf, (QUANTIZATION_EXTENSION,))
+    return bytes(new_bin)
+
+
+def decompress_glb(path: str) -> str:
+    """
+    Return a path to a GLB without meshopt compression / mesh quantization.
+
+    If preparation is unnecessary, returns ``path``. Otherwise writes a
+    temporary ``.glb`` and returns that path. Caller should delete temps via
+    ``cleanup_decompressed``.
+    """
+    if not needs_meshopt_decompress(path):
+        return path
+
+    gltf, bin_chunk = _read_glb(path)
+    changed = False
+
+    if _gltf_has_meshopt(gltf):
+        bin_chunk = _decompress_meshopt(gltf, bin_chunk)
+        changed = True
+
+    if _gltf_has_quantization(gltf):
+        bin_chunk = _dequant_mesh_quantization(gltf, bin_chunk)
+        changed = True
+
+    if not changed:
+        return path
 
     fd, temp_path = tempfile.mkstemp(prefix="exhibit-meshopt-", suffix=".glb")
     os.close(fd)
     try:
-        _write_glb(temp_path, gltf, bytes(new_bin))
+        _write_glb(temp_path, gltf, bin_chunk)
     except Exception:
         cleanup_decompressed(temp_path)
         raise

--- a/src/meshopt_decompress.py
+++ b/src/meshopt_decompress.py
@@ -144,7 +144,9 @@ def _configure_lib(lib: CDLL) -> None:
         "meshopt_decodeFilterExp",
         "meshopt_decodeFilterColor",
     ):
-        fn = getattr(lib, filter_name)
+        fn = getattr(lib, filter_name, None)
+        if fn is None:
+            continue
         fn.argtypes = [c_void_p, c_size_t, c_size_t]
         fn.restype = None
 
@@ -284,7 +286,11 @@ def _decode_view(lib: CDLL, source: bytes, ext: dict[str, Any]) -> bytes:
     if count < 0 or stride <= 0:
         raise MeshoptError("Invalid meshopt bufferView parameters")
 
-    destination = (c_ubyte * (count * stride))()
+    # meshopt filters process vertices in groups of 4 and may write past
+    # ``count`` up to the next multiple of 4 — allocate that pad.
+    count4 = (count + 3) & ~3
+    alloc_count = count4 if filter_name != "NONE" else count
+    destination = (c_ubyte * (alloc_count * stride))()
     source_buf = (c_ubyte * len(source)).from_buffer_copy(source)
 
     decoders = {
@@ -302,21 +308,23 @@ def _decode_view(lib: CDLL, source: bytes, ext: dict[str, Any]) -> bytes:
 
     filters = {
         "NONE": None,
-        "OCTAHEDRAL": lib.meshopt_decodeFilterOct,
-        "QUATERNION": lib.meshopt_decodeFilterQuat,
-        "EXPONENTIAL": lib.meshopt_decodeFilterExp,
-        "COLOR": lib.meshopt_decodeFilterColor,
+        "OCTAHEDRAL": getattr(lib, "meshopt_decodeFilterOct", None),
+        "QUATERNION": getattr(lib, "meshopt_decodeFilterQuat", None),
+        "EXPONENTIAL": getattr(lib, "meshopt_decodeFilterExp", None),
+        "COLOR": getattr(lib, "meshopt_decodeFilterColor", None),
     }
     if filter_name not in filters:
         raise MeshoptError(f"Unsupported meshopt filter: {filter_name}")
 
     filter_fn = filters[filter_name]
+    if filter_name != "NONE" and filter_fn is None:
+        raise MeshoptError(
+            f"meshopt filter {filter_name} is not available in libmeshoptimizer"
+        )
     if filter_fn is not None:
-        # Match meshoptimizer JS decoder: round count up to multiple of 4.
-        count4 = (count + 3) & ~3
         filter_fn(cast(destination, c_void_p), count4, stride)
 
-    return bytes(destination)
+    return bytes(destination)[: count * stride]
 
 
 def _align4(value: int) -> int:

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ exhibit_sources = [
   'vector_math.py',
   'logger_lib.py',
   'settings_manager.py',
+  'meshopt_decompress.py',
 ]
 
 install_data(exhibit_sources, install_dir: moduledir)

--- a/src/widgets/f3d_viewer.py
+++ b/src/widgets/f3d_viewer.py
@@ -23,6 +23,7 @@ import f3d
 
 from ..vector_math import p_dist, v_abs, v_norm, v_add, v_sub, v_mul, v_dot_p
 from .. import logger_lib
+from ..meshopt_decompress import MeshoptError, cleanup_decompressed, prepare_glb_for_load
 
 up_dirs_vector = {
     "-X": (-1.0, 0.0, 0.0),
@@ -298,6 +299,13 @@ class F3DViewer(Gtk.GLArea):
     def supports(self, filepath):
         return self.scene.supports(filepath)
 
+    def _prepare_filepath(self, filepath):
+        try:
+            return prepare_glb_for_load(filepath)
+        except MeshoptError as e:
+            self.logger.error(f"Error while decompressing meshopt GLB: {e}")
+            return None, None
+
     def load_file(self, filepath):
         if self.settings["render.hdri.ambient"]:
             f3d_options = {"render.hdri.ambient": False}
@@ -305,11 +313,17 @@ class F3DViewer(Gtk.GLArea):
 
         self.scene.clear()
 
+        load_path, meshopt_temp = self._prepare_filepath(filepath)
+        if load_path is None:
+            return False
+
         try:
-            self.scene.add(filepath)
+            self.scene.add(load_path)
         except Exception as e:
             self.logger.error(f"Error while loading file: {e}")
             return False
+        finally:
+            cleanup_decompressed(meshopt_temp)
 
         self.notify("lower-time-range")
         self.notify("upper-time-range")
@@ -321,11 +335,17 @@ class F3DViewer(Gtk.GLArea):
             f3d_options = {"render.hdri.ambient": False}
             self.engine.options.update(f3d_options)
 
+        load_path, meshopt_temp = self._prepare_filepath(filepath)
+        if load_path is None:
+            return False
+
         try:
-            self.scene.add(filepath)
+            self.scene.add(load_path)
         except Exception as e:
             self.logger.error(f"Error while loading file: {e}")
             return False
+        finally:
+            cleanup_decompressed(meshopt_temp)
 
         self.notify("lower-time-range")
         self.notify("upper-time-range")

--- a/src/window.py
+++ b/src/window.py
@@ -28,6 +28,7 @@ from wand.image import Image
 
 from . import logger_lib
 from .settings_manager import WindowSettings
+from .meshopt_decompress import MeshoptError, cleanup_decompressed, prepare_glb_for_load
 
 import f3d
 
@@ -886,18 +887,30 @@ class Viewer3dWindow(Adw.ApplicationWindow):
             self.logger.debug(f"best settings is {settings}")
             self.change_setting_state(GLib.Variant("s", settings))
 
-        if self.f3d_viewer.supports(filepath):
-            if add_file:
-                if not self.f3d_viewer.add_file(filepath):
-                    GLib.idle_add(self.on_file_not_opened, filepath)
-                    return
-            else:
-                if not self.f3d_viewer.load_file(filepath):
-                    GLib.idle_add(self.on_file_not_opened, filepath)
-                    return
-        else:
+        load_path = filepath
+        meshopt_temp = None
+        try:
+            load_path, meshopt_temp = prepare_glb_for_load(filepath)
+        except MeshoptError as e:
+            self.logger.error(f"Error while decompressing meshopt GLB: {e}")
             GLib.idle_add(self.on_file_not_opened, filepath)
             return
+
+        try:
+            if self.f3d_viewer.supports(load_path):
+                if add_file:
+                    if not self.f3d_viewer.add_file(load_path):
+                        GLib.idle_add(self.on_file_not_opened, filepath)
+                        return
+                else:
+                    if not self.f3d_viewer.load_file(load_path):
+                        GLib.idle_add(self.on_file_not_opened, filepath)
+                        return
+            else:
+                GLib.idle_add(self.on_file_not_opened, filepath)
+                return
+        finally:
+            cleanup_decompressed(meshopt_temp)
 
         if preserve_orientation:
             self.f3d_viewer.set_camera_state(camera_state)


### PR DESCRIPTION
## Summary
- Adds `libmeshoptimizer` to the Flatpak manifest so Exhibit can decode `EXT_meshopt_compression` / `KHR_meshopt_compression`.
- Introduces `src/meshopt_decompress.py` to expand meshopt GLBs into a temporary uncompressed `.glb` before F3D/VTK load (VTK and Assimp cannot read these extensions).
- Also expands `KHR_mesh_quantization` mesh attributes (`POSITION` / `NORMAL` / `TANGENT` / `TEXCOORD_*`) to float and strips that extension (common with gltfpack `-c`).
- Hooks preparation in `_load_file` (before `supports()`) and in `F3DViewer.load_file` / `add_file`.
- Grants Flatpak `--filesystem=home` and `--filesystem=/tmp` so CLI/drop loads of local files work (portal-only sandbox previously failed those paths with a generic load error).

## Test plan
- [ ] Flatpak CI build succeeds (new `meshoptimizer` module)
- [ ] Open a normal (uncompressed) `.glb` — behavior unchanged
- [ ] Open a GLB with `EXT_meshopt_compression` only (e.g. gltfpack `-c -noq`) — model loads
- [ ] Open a GLB with `EXT_meshopt_compression` + `KHR_mesh_quantization` (e.g. gltfpack `-c`) — model loads
- [ ] Open a GLB with `KHR_mesh_quantization` only (no meshopt) — model loads
- [ ] Open a GLB with `KHR_meshopt_compression` — model loads
- [ ] Confirm temp `exhibit-meshopt-*.glb` files are removed after load
- [ ] `flatpak run io.github.nokse22.Exhibit /tmp/some.glb` and a file under `$HOME` both load