### PR TITLE
feat: select animations by name without reloading

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -706,13 +706,11 @@
                                       <object class="AdwPreferencesGroup" id="animation_group">
                                         <property name="title" translatable="yes">Animation</property>
                                         <child>
-                                          <object class="AdwSpinRow">
-                                            <property name="title" translatable="yes">Animation Index</property>
-                                            <property name="adjustment">
-                                              <object class="GtkAdjustment" id="animation_index_adj">
-                                                <property name="upper">99</property>
-                                                <property name="step-increment">1.0</property>
-                                              </object>
+                                          <object class="AdwComboRow" id="animation_combo">
+                                            <property name="title" translatable="yes">Active animation</property>
+                                            <property name="subtitle" translatable="yes">Changing it will reload the file</property>
+                                            <property name="model">
+                                              <object class="GtkStringList" id="animation_list"/>
                                             </property>
                                           </object>
                                         </child>

--- a/src/widgets/f3d_viewer.py
+++ b/src/widgets/f3d_viewer.py
@@ -83,7 +83,7 @@ class F3DViewer(Gtk.GLArea):
         "grid-subdivisions": "render.grid.subdivisions",
         "grid-color": "render.grid.color",
         "scalar": "model.scivis.array_name",  # rename to scivis-name
-        "animation-index": "scene.animation.index",
+        "animation-index": "scene.animation.indices",
     }
 
     def __init__(self, *args):
@@ -281,6 +281,8 @@ class F3DViewer(Gtk.GLArea):
         for key, value in options.items():
             if key in self.keys:
                 f3d_key = self.keys[key]
+                if key == "animation-index" and not isinstance(value, (list, tuple)):
+                    value = [int(value)]
                 self.settings[f3d_key] = value
                 f3d_options[f3d_key] = value
 
@@ -288,6 +290,16 @@ class F3DViewer(Gtk.GLArea):
         if self.engine:
             self.engine.options.update(f3d_options)
             self.queue_render()
+
+    def available_animations(self):
+        if not self.scene:
+            return 0
+        return int(self.scene.available_animations())
+
+    def get_animation_names(self):
+        if not self.scene:
+            return []
+        return list(self.scene.get_animation_names())
 
     def render_image(self):
         self.get_context().make_current()

--- a/src/window.py
+++ b/src/window.py
@@ -606,10 +606,15 @@ class Viewer3dWindow(Adw.ApplicationWindow):
         index = self._animation_index_from_combo()
         self.window_settings.set_setting("animation-index", index)
         self.f3d_viewer.update_options({"animation-index": index})
-        self.f3d_viewer.animation_time = self.f3d_viewer.lower_time_range
         self.f3d_viewer.playing = False
-
-        GLib.timeout_add(100, self.reload_file, True)
+        # F3D switches clip via scene.animation.indices — no file reload.
+        lower = self.f3d_viewer.lower_time_range
+        upper = self.f3d_viewer.upper_time_range
+        self.animation_time_adj.set_lower(lower)
+        self.animation_time_adj.set_upper(upper)
+        self.f3d_viewer.notify("lower-time-range")
+        self.f3d_viewer.notify("upper-time-range")
+        self.f3d_viewer.animation_time = lower
 
     def on_switch_toggled(self, switch, active, name):
         self.window_settings.set_setting(name, switch.get_active())

--- a/src/window.py
+++ b/src/window.py
@@ -177,8 +177,8 @@ class Viewer3dWindow(Adw.ApplicationWindow):
     save_settings_expander = Gtk.Template.Child()
 
     animation_group = Gtk.Template.Child()
+    animation_combo = Gtk.Template.Child()
     animation_time_adj = Gtk.Template.Child()
-    animation_index_adj = Gtk.Template.Child()
     play_button = Gtk.Template.Child()
 
     width = 600
@@ -429,8 +429,9 @@ class Viewer3dWindow(Adw.ApplicationWindow):
 
         self.f3d_viewer.connect("notify::playing", self.on_playing_changed)
 
-        self.animation_index_adj.connect_after(
-            "value-changed", self.on_animation_index_changed)
+        self._block_animation_combo = False
+        self.animation_combo.connect(
+            "notify::selected", self.on_animation_combo_changed)
 
         self.block_reload = True
 
@@ -550,9 +551,61 @@ class Viewer3dWindow(Adw.ApplicationWindow):
     # Functions that are called when a UI changes, they should only
     #   set the corresponding setting.
 
-    def on_animation_index_changed(self, *args):
-        self.f3d_viewer.update_options(
-            {"animation-index": int(self.animation_index_adj.get_value())})
+    def _animation_index_from_combo(self):
+        selected = self.animation_combo.get_selected()
+        if selected == Gtk.INVALID_LIST_POSITION:
+            return 0
+        # First item is "All animations" → -1
+        if selected == 0:
+            return -1
+        return int(selected) - 1
+
+    def _combo_position_for_animation_index(self, index):
+        if index < 0:
+            return 0
+        return int(index) + 1
+
+    def refresh_animation_combo(self):
+        count = self.f3d_viewer.available_animations()
+        if count <= 0:
+            self.animation_group.set_visible(False)
+            return
+
+        names = self.f3d_viewer.get_animation_names()
+        string_list = Gtk.StringList()
+        string_list.append(_("All animations"))
+        for i in range(count):
+            name = names[i] if i < len(names) else ""
+            if name:
+                string_list.append(name)
+            else:
+                string_list.append(_("Animation {}").format(i))
+
+        current = self.window_settings.get_setting("animation-index").value
+        if current >= count:
+            current = 0
+            self.window_settings.set_setting("animation-index", current, False)
+
+        position = self._combo_position_for_animation_index(current)
+        if position >= string_list.get_n_items():
+            position = 1 if count > 0 else 0
+
+        self._block_animation_combo = True
+        try:
+            self.animation_combo.set_model(string_list)
+            self.animation_combo.set_selected(position)
+        finally:
+            self._block_animation_combo = False
+
+        self.animation_group.set_visible(True)
+
+    def on_animation_combo_changed(self, *args):
+        if self._block_animation_combo:
+            return
+
+        index = self._animation_index_from_combo()
+        self.window_settings.set_setting("animation-index", index)
+        self.f3d_viewer.update_options({"animation-index": index})
         self.f3d_viewer.animation_time = self.f3d_viewer.lower_time_range
         self.f3d_viewer.playing = False
 
@@ -923,10 +976,7 @@ class Viewer3dWindow(Adw.ApplicationWindow):
 
         self.update_background_color()
 
-        if self.f3d_viewer.upper_time_range == 0.0:
-            self.animation_group.set_visible(False)
-        else:
-            self.animation_group.set_visible(True)
+        self.refresh_animation_combo()
 
         self.block_reload = False
         GLib.timeout_add(100, self.f3d_viewer.done)


### PR DESCRIPTION
## Summary
- Replace the animation index spin row with an `AdwComboRow` populated from F3D `get_animation_names()`, including an **All animations** entry.
- Map `animation-index` to `scene.animation.indices` (list form expected by current F3D).
- Changing the active clip updates options and scrubber bounds in place — no full model reload.

## Test plan
- [ ] Open a GLB/glTF with multiple named animations (e.g. Khronos Fox)
- [ ] Sidebar shows **Active animation** combo with clip names
- [ ] Switching clips updates the pose/scrubber range without reloading the file
- [ ] **All animations** still works
- [ ] Models without animations hide the animation group
- [ ] Play/pause and time scrubber still work after switching clips